### PR TITLE
Fix broken order of linker sources in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ RM = rm -f
 .SUFFIXES: .cpp .o
 
 $(RESULT): $(OBJECTS)
-	$(CC) $(CFLAGS) $(LIBS) -o $@ $^
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
 obj/%.o: src/%.cpp
 	g++ $(CFLAGS) -c -o $@ $<


### PR DESCRIPTION
Prompted by http://stackoverflow.com/q/28889744/85371 which reports the problem on Yosemite:

I am trying to compile a program from

https://github.com/davidsd/sdpb

with gcc-4.9, boost 1.57.0, gmp-6.0.0a, and mpfr-3.1.2 on OS X 10.10.2, but I keep getting errors seemingly related to the gmp and mpfr packages.  I know somebody who successfully compiled on 10.9.5.  Can anybody suggest a fix?

-----

Undefined symbols for architecture x86_64:
  "operator<<(std::basic_ostream<char, std::char_traits<char> >&, __mpf_struct const*)", referenced from:

      operator<<(std::basic_ostream<char, std::char_traits<char> >&, Matrix const&) in Matrix.o
      operator<<(std::basic_ostream<char, std::char_traits<char> >&, SDPSolverParameters const&) in SDPSolverIO.o
      SDPSolver::saveSolution(SDPSolverTerminateReason, boost::filesystem::path const&)  in SDPSolverIO.o
      std::basic_ostream<char, std::char_traits<char> >& operator<< <__gmp_expr<__mpf_struct [1], __mpf_struct [1]> >(std::basic_ostream<char, std::char_traits<char> >&, std::vector<__gmp_expr<__mpf_struct [1], __mpf_struct [1]>, std::allocator<__gmp_expr<__mpf_struct [1], __mpf_struct [1]> > > const&) in SDPSolverIO.o
      void boost::serialization::save<boost::archive::text_oarchive>(boost::archive::text_oarchive&, __gmp_expr<__mpf_struct [1], __mpf_struct [1]> const&, unsigned int) in SDPSolverIO.o
      solveSDP(boost::filesystem::path const&, boost::filesystem::path const&, boost::filesystem::path const&, SDPSolverParameters) in main.o
      boost::detail::lexical_converter_impl<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, __gmp_expr<__mpf_struct [1], __mpf_struct [1]> >::try_convert(__gmp_expr<__mpf_struct [1], __mpf_struct [1]> const&, std::basic_string<char, std::char_traits<char>, std::allocator<char> >&) in main.o
      ...

  "operator>>(std::basic_istream<char, std::char_traits<char> >&, __mpf_struct*)", referenced from:

      void boost::program_options::validate<__gmp_expr<__mpf_struct [1], __mpf_struct [1]>, char>(boost::any&, std::vector<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, __gmp_expr<__mpf_struct [1], __mpf_struct [1]>*, long) in main.o
ld: symbol(s) not found for architecture x86_64
collect2: error: ld returned 1 exit status
make: *** [sdpb] Error 1