### PR TITLE
Added BOOST_WINDOWS_API support to parse.cpp

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -92,10 +92,12 @@ SDP parseBootstrapSDP(XMLElement *xml) {
 
 SDP readBootstrapSDP(const path sdpFile) {
   XMLDocument doc;
+  
 #ifndef BOOST_WINDOWS_API
   doc.LoadFile(sdpFile.c_str());
 #else
   doc.LoadFile(sdpFile.string().c_str());
 #endif  
-return parseBootstrapSDP(doc.FirstChildElement("sdp"));
+
+  return parseBootstrapSDP(doc.FirstChildElement("sdp"));
 }

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -92,6 +92,10 @@ SDP parseBootstrapSDP(XMLElement *xml) {
 
 SDP readBootstrapSDP(const path sdpFile) {
   XMLDocument doc;
+#ifndef BOOST_WINDOWS_API
   doc.LoadFile(sdpFile.c_str());
-  return parseBootstrapSDP(doc.FirstChildElement("sdp"));
+#else
+  doc.LoadFile(sdpFile.string().c_str());
+#endif  
+return parseBootstrapSDP(doc.FirstChildElement("sdp"));
 }


### PR DESCRIPTION
path.c_str() returns value_type\*, which is a wchar_t\* if BOOST_WINDOWS_API is defined. Tinyxml uses fopen to open files, which does not take wchar_t argument. This fix leaves tinyxml invariant, but there can be an error if a file with non-ascii characters is being opened. As far as ascii characters are concerned, everything should be ok. I don't know a good solution to this problem, here's why. Windows standard workaround is wfopen, but this function is not available on Cygwin, which is the environment that is most likely to be used on Windows to build sdpb. The reason for no wfopen is that Cygwin follows posix. However, boost does not believe that cygwin is posix and defines BOOST_WINDOWS_API. Perhaps I missed something, but that seems to be the situation.