### PR TITLE
Use the system version of tinyxml2.h when using a shared tinyxml2 library.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ RESULT  = sdpb
 
 ifeq ($(SHARED_TINYXML2), 1)
 LIBS = -ltinyxml2
+CFLAGS += -D___SHARED_TINYXML2___
 else
 SOURCES += $(wildcard src/tinyxml2/*.cpp)
 HEADERS += $(wildcard src/tinyxml2/*.h)

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -19,7 +19,11 @@
 #include "parse.h"
 #include "Polynomial.h"
 #include "SDP.h"
+#ifdef ___SHARED_TINYXML2___
+#include <tinyxml2.h>
+#else
 #include "tinyxml2/tinyxml2.h"
+#endif
 
 using std::vector;
 using tinyxml2::XMLDocument;


### PR DESCRIPTION
Turns out that this (the embedded copy of tinyxml2.h was still used) was the cause for the crashes described in issue  #17.