### PR TITLE
Update Install.md (sdpb is included in Ubuntu 17.04).

### DIFF
--- a/Install.md
+++ b/Install.md
@@ -35,11 +35,11 @@ SDPB has been tested on Red Hat Linux. To install,
 
 ### Debian/Ubuntu
 
-SDPB was included in Debian and is expected to be part of stable releases starting from Debian 10 and Ubuntu 17.10.
+SDPB was included in Debian and is expected to be part of stable releases starting from Debian 10 and Ubuntu 17.04.
 When using such a release, it is enough to install the package sdpb (and sdpb-doc for documentation).
 
-On Debian 9 and Ubuntu 17.04 one can try to download the package from [here](https://packages.debian.org/sid/sdpb)
-and install it manually. The package is not installable on older releases due to a mismatch in Boost versions.
+On Debian 9 one can try to download the package from [here](https://packages.debian.org/sid/sdpb) and install it
+manually. The package is not installable on older releases of Debian or Ubuntu due to a mismatch in Boost versions.
 
 ## Mac OS X
 


### PR DESCRIPTION
I thought sdpb would only be included in Ubuntu 17.10 because Ubuntu had a "Debian import freeze" in February. But the package appeared in 17.04, so apparently they were still importing new packages.