### PR TITLE
Add in-tree singularity build

### DIFF
--- a/singularity/Makefile
+++ b/singularity/Makefile
@@ -1,0 +1,22 @@
+CONTAINERS=sdpb.sif base.sif
+SINGULARITY=singularity
+SINGULARITY_ROOT=sudo $(SINGULARITY)
+
+.PHONY: all
+all: sdpb.sif sdpb_tested.txt
+
+.PHONY: clean clean_tests
+clean_tests:
+	rm -rf test
+	rm sdpb_tested.txt
+
+clean: clean_tests
+	rm -f ${CONTAINERS}
+
+%.sif: %.def
+	$(SINGULARITY_ROOT) build --force --notest $@ $<
+
+sdpb.sif: base.sif $(shell find ../src -type f)
+
+sdpb_tested.txt: sdpb.sif
+	$(SINGULARITY) test sdpb.sif&&touch sdpb_tested.txt

--- a/singularity/base.def
+++ b/singularity/base.def
@@ -1,0 +1,82 @@
+Bootstrap: docker
+From: centos:8
+
+%runscript
+
+%files
+
+%environment
+
+%labels
+
+%post
+dnf install -y dnf-plugins-core
+dnf install -y gcc-c++ gcc-gfortran
+dnf install -y epel-release
+dnf install -y diffutils which
+dnf install -y git wget
+dnf install -y gdb valgrind
+dnf install -y make bzip2 autoconf automake libtool cmake 
+dnf install -y python3 python3-devel
+dnf install -y boost boost-devel
+dnf install -y openmpi openmpi-devel environment-modules
+dnf install -y gmp gmp-c++ gmp-devel mpfr mpfr-devel
+dnf install -y libxml2-devel libxml2
+
+
+source /usr/share/Modules/init/bash
+module load mpi
+
+# ========= Source Builds =========
+mkdir /base
+pushd /base
+mkdir scratch
+
+# ========== RapidJSON =======
+
+pushd scratch
+wget https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz
+tar -xzf v1.1.0.tar.gz
+cd rapidjson-1.1.0
+cp -r include/rapidjson /usr/local/include
+popd
+
+# ========== OpenBLAS ========
+
+pushd scratch
+wget https://github.com/xianyi/OpenBLAS/archive/v0.3.9.tar.gz
+tar -xzf v0.3.9.tar.gz
+cd OpenBLAS-0.3.9
+make -j$(nproc) \
+TARGET=${BLAS_TARGET_ARCH:-HASWELL} #INTERFACE64=1
+export OPENBLASDIR=/usr/local
+make install PREFIX=${OPENBLASDIR}
+popd
+
+# ========== Elemental =========
+
+pushd scratch
+
+export CXX=mpicxx
+export CC=mpicc
+git clone https://gitlab.com/bootstrapcollaboration/elemental.git
+
+mkdir -p elemental/build
+cd elemental/build
+
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc) 
+make install
+popd
+
+# ======== Python Setup ========
+
+python3 -m venv /base/python
+source /base/python/bin/activate
+deactivate
+
+# ======== Cleanup ======
+
+dnf clean all
+rm -rf /var/cache/yum
+rm -rf /base/scratch

--- a/singularity/sdpb.def
+++ b/singularity/sdpb.def
@@ -1,0 +1,39 @@
+Bootstrap: localimage
+From: ./base.sif
+
+%runscript
+sdpb $@
+
+%files
+../ /src
+
+%environment
+export SHELL=/bin/bash
+export SDPB_PVM2SDP=pvm2sdp
+export SDPB_SDPB=sdpb
+source /base/python/bin/activate
+source /usr/share/Modules/init/bash
+module load mpi
+
+
+%labels
+
+%test
+# Container dirs are immutable after bootstrap
+cp -n -r /src/test test
+SDPB_TESTPREFIX=test
+test/run_test.sh
+
+%post
+# HACK: Since the build is in-tree we end up copying various build outputs
+rm -rf /src/singularity
+
+source /usr/share/Modules/init/bash
+module load mpi
+
+source /base/python/bin/activate
+
+cd /src
+CXX=mpicxx ./waf configure --elemental-dir=/usr/local/
+./waf -j$(nproc)
+./waf install

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -3,8 +3,12 @@
 # Run this from the top level directory
 result=0
 
-rm -rf test/test/
-./build/pvm2sdp 1024 test/file_list.nsv test/test/
+: "${SDPB_PVM2SDP:=./build/pvm2sdp}"
+: "${SDPB_SDPB:=./build/sdpb}"
+: "${SDPB_TESTPREFIX:=test}"
+
+rm -rf ${SDPB_TESTPREFIX}/test/
+${SDPB_PVM2SDP} 1024 ${SDPB_TESTPREFIX}/file_list.nsv ${SDPB_TESTPREFIX}/test/
 if [ $? == 0 ]
 then
     echo "PASS pvm2sdp"
@@ -13,9 +17,9 @@ else
     result=1
 fi
 
-rm -f test/test.out
-./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/test/ --verbosity=0
-diff test/test_out test/test_out_orig
+rm -f ${SDPB_TESTPREFIX}/test.out
+${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/test/ --verbosity=0
+diff ${SDPB_TESTPREFIX}/test_out ${SDPB_TESTPREFIX}/test_out_orig
 if [ $? == 0 ]
 then
     echo "PASS SDPB"
@@ -23,12 +27,12 @@ else
     echo "FAIL SDPB"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-touch test/io_tests/profile_error.profiling.0
-chmod a-w test/io_tests/profile_error.profiling.0
-mpirun -n 2 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/test/ -c test/io_tests/profile_error --verbosity=2 --maxIterations=1 2>/dev/null > /dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+touch ${SDPB_TESTPREFIX}/io_tests/profile_error.profiling.0
+chmod a-w ${SDPB_TESTPREFIX}/io_tests/profile_error.profiling.0
+mpirun -n 2 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/test/ -c ${SDPB_TESTPREFIX}/io_tests/profile_error --verbosity=2 --maxIterations=1 2>/dev/null > /dev/null
 if [ $? != 0 ]
 then
     echo "PASS write profile"
@@ -36,12 +40,12 @@ else
     echo "FAIL write profile"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-touch test/io_tests/bilinear_bases.0
-chmod a-w test/io_tests/bilinear_bases.0
-mpirun -n 1 --quiet ./build/pvm2sdp 1024 test/test.xml test/io_tests 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+touch ${SDPB_TESTPREFIX}/io_tests/bilinear_bases.0
+chmod a-w ${SDPB_TESTPREFIX}/io_tests/bilinear_bases.0
+mpirun -n 1 --quiet ${SDPB_PVM2SDP} 1024 ${SDPB_TESTPREFIX}/test.xml ${SDPB_TESTPREFIX}/io_tests 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS bilinear_bases"
@@ -49,12 +53,12 @@ else
     echo "FAIL bilinear_bases"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-touch test/io_tests/blocks.0
-chmod a-w test/io_tests/blocks.0
-mpirun -n 1 --quiet ./build/pvm2sdp 1024 test/test.xml test/io_tests 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+touch ${SDPB_TESTPREFIX}/io_tests/blocks.0
+chmod a-w ${SDPB_TESTPREFIX}/io_tests/blocks.0
+mpirun -n 1 --quiet ${SDPB_PVM2SDP} 1024 ${SDPB_TESTPREFIX}/test.xml ${SDPB_TESTPREFIX}/io_tests 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS blocks"
@@ -62,12 +66,12 @@ else
     echo "FAIL blocks"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-touch test/io_tests/free_var_matrix.0
-chmod a-w test/io_tests/free_var_matrix.0
-mpirun -n 1 --quiet ./build/pvm2sdp 1024 test/test.xml test/io_tests 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+touch ${SDPB_TESTPREFIX}/io_tests/free_var_matrix.0
+chmod a-w ${SDPB_TESTPREFIX}/io_tests/free_var_matrix.0
+mpirun -n 1 --quiet ${SDPB_PVM2SDP} 1024 ${SDPB_TESTPREFIX}/test.xml ${SDPB_TESTPREFIX}/io_tests 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS free_var_matrix"
@@ -75,12 +79,12 @@ else
     echo "FAIL free_var_matrix"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-touch test/io_tests/objectives
-chmod a-w test/io_tests/objectives
-mpirun -n 1 --quiet ./build/pvm2sdp 1024 test/test.xml test/io_tests 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+touch ${SDPB_TESTPREFIX}/io_tests/objectives
+chmod a-w ${SDPB_TESTPREFIX}/io_tests/objectives
+mpirun -n 1 --quiet ${SDPB_PVM2SDP} 1024 ${SDPB_TESTPREFIX}/test.xml ${SDPB_TESTPREFIX}/io_tests 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS objectives"
@@ -88,12 +92,12 @@ else
     echo "FAIL objectives"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-touch test/io_tests/primal_objective_c.0
-chmod a-w test/io_tests/primal_objective_c.0
-mpirun -n 1 --quiet ./build/pvm2sdp 1024 test/test.xml test/io_tests 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+touch ${SDPB_TESTPREFIX}/io_tests/primal_objective_c.0
+chmod a-w ${SDPB_TESTPREFIX}/io_tests/primal_objective_c.0
+mpirun -n 1 --quiet ${SDPB_PVM2SDP} 1024 ${SDPB_TESTPREFIX}/test.xml ${SDPB_TESTPREFIX}/io_tests 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS primal_objective_c"
@@ -101,13 +105,13 @@ else
     echo "FAIL primal_objective_c"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-mkdir test/io_tests/out
-touch test/io_tests/out/out.txt
-chmod a-w test/io_tests/out/out.txt
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/test/ -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+mkdir ${SDPB_TESTPREFIX}/io_tests/out
+touch ${SDPB_TESTPREFIX}/io_tests/out/out.txt
+chmod a-w ${SDPB_TESTPREFIX}/io_tests/out/out.txt
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/test/ -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS out.txt"
@@ -115,13 +119,13 @@ else
     echo "FAIL out.txt"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-mkdir test/io_tests/out
-touch test/io_tests/out/x_0.txt
-chmod a-w test/io_tests/out/x_0.txt
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/test/ -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+mkdir ${SDPB_TESTPREFIX}/io_tests/out
+touch ${SDPB_TESTPREFIX}/io_tests/out/x_0.txt
+chmod a-w ${SDPB_TESTPREFIX}/io_tests/out/x_0.txt
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/test/ -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS x_0.txt"
@@ -129,13 +133,13 @@ else
     echo "FAIL x_0.txt"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-mkdir test/io_tests/out
-touch test/io_tests/out/y.txt
-chmod a-w test/io_tests/out/y.txt
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/test/ -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+mkdir ${SDPB_TESTPREFIX}/io_tests/out
+touch ${SDPB_TESTPREFIX}/io_tests/out/y.txt
+chmod a-w ${SDPB_TESTPREFIX}/io_tests/out/y.txt
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/test/ -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS y.txt"
@@ -143,13 +147,13 @@ else
     echo "FAIL y.txt"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-mkdir test/io_tests/out
-touch test/io_tests/out/X_matrix_0.txt
-chmod a-w test/io_tests/out/X_matrix_0.txt
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/test/ -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --writeSolution=x,y,X,Y --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+mkdir ${SDPB_TESTPREFIX}/io_tests/out
+touch ${SDPB_TESTPREFIX}/io_tests/out/X_matrix_0.txt
+chmod a-w ${SDPB_TESTPREFIX}/io_tests/out/X_matrix_0.txt
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/test/ -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --writeSolution=x,y,X,Y --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS X_matrix_0.txt"
@@ -157,13 +161,13 @@ else
     echo "FAIL X_matrix_0.txt"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-mkdir test/io_tests/out
-touch test/io_tests/out/Y_matrix_0.txt
-chmod a-w test/io_tests/out/Y_matrix_0.txt
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/test/ -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --writeSolution=x,y,X,Y --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+mkdir ${SDPB_TESTPREFIX}/io_tests/out
+touch ${SDPB_TESTPREFIX}/io_tests/out/Y_matrix_0.txt
+chmod a-w ${SDPB_TESTPREFIX}/io_tests/out/Y_matrix_0.txt
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/test/ -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --writeSolution=x,y,X,Y --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS Y_matrix_0.txt"
@@ -171,11 +175,11 @@ else
     echo "FAIL Y_matrix_0.txt"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-echo "file_does_not_exist" > test/io_tests/file_list.nsv
-mpirun -n 1 --quiet ./build/pvm2sdp 1024 test/io_tests/file_list.nsv test/io_tests 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+echo "file_does_not_exist" > ${SDPB_TESTPREFIX}/io_tests/file_list.nsv
+mpirun -n 1 --quiet ${SDPB_PVM2SDP} 1024 ${SDPB_TESTPREFIX}/io_tests/file_list.nsv ${SDPB_TESTPREFIX}/io_tests 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS file_list.nsv"
@@ -183,12 +187,12 @@ else
     echo "FAIL file_list.nsv"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-chmod a-r test/io_tests/test/blocks.0
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+chmod a-r ${SDPB_TESTPREFIX}/io_tests/test/blocks.0
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS blocks"
@@ -196,12 +200,12 @@ else
     echo "FAIL blocks"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-chmod a-r test/io_tests/test/blocks.0
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+chmod a-r ${SDPB_TESTPREFIX}/io_tests/test/blocks.0
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS blocks"
@@ -209,13 +213,13 @@ else
     echo "FAIL blocks"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-rm test/io_tests/test/blocks.0
-touch test/io_tests/test/blocks.0
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+rm ${SDPB_TESTPREFIX}/io_tests/test/blocks.0
+touch ${SDPB_TESTPREFIX}/io_tests/test/blocks.0
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS blocks corruption"
@@ -223,12 +227,12 @@ else
     echo "FAIL blocks corruption"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-head -n 1 test/io_tests/test/blocks.0 > test/io_tests/test/blocks.0
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+head -n 1 ${SDPB_TESTPREFIX}/io_tests/test/blocks.0 > ${SDPB_TESTPREFIX}/io_tests/test/blocks.0
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS vector size"
@@ -236,12 +240,12 @@ else
     echo "FAIL vector size"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-head -n 2 test/io_tests/test/blocks.0 > test/io_tests/test/blocks.0
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+head -n 2 ${SDPB_TESTPREFIX}/io_tests/test/blocks.0 > ${SDPB_TESTPREFIX}/io_tests/test/blocks.0
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS vector element"
@@ -249,12 +253,12 @@ else
     echo "FAIL vector element"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-chmod a-r test/io_tests/test/bilinear_bases.0
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+chmod a-r ${SDPB_TESTPREFIX}/io_tests/test/bilinear_bases.0
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS bilinear read"
@@ -262,13 +266,13 @@ else
     echo "FAIL bilinear read"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-rm test/io_tests/test/bilinear_bases.0
-touch test/io_tests/test/bilinear_bases.0
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+rm ${SDPB_TESTPREFIX}/io_tests/test/bilinear_bases.0
+touch ${SDPB_TESTPREFIX}/io_tests/test/bilinear_bases.0
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS bilinear empty"
@@ -276,12 +280,12 @@ else
     echo "FAIL bilinear empty"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-head -n 2 test/io_tests/test/bilinear_bases.0 > test/io_tests/test/bilinear_bases.0
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+head -n 2 ${SDPB_TESTPREFIX}/io_tests/test/bilinear_bases.0 > ${SDPB_TESTPREFIX}/io_tests/test/bilinear_bases.0
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS bilinear header"
@@ -289,12 +293,12 @@ else
     echo "FAIL bilinear header"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-head -n 26 test/io_tests/test/bilinear_bases.0 > test/io_tests/test/bilinear_bases.0
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+head -n 26 ${SDPB_TESTPREFIX}/io_tests/test/bilinear_bases.0 > ${SDPB_TESTPREFIX}/io_tests/test/bilinear_bases.0
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS bilinear data"
@@ -302,12 +306,12 @@ else
     echo "FAIL bilinear data"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-chmod a-r test/io_tests/test/free_var_matrix.0
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+chmod a-r ${SDPB_TESTPREFIX}/io_tests/test/free_var_matrix.0
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS free_var_matrix read"
@@ -315,13 +319,13 @@ else
     echo "FAIL free_var_matrix read"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-rm test/io_tests/test/free_var_matrix.0
-touch test/io_tests/test/free_var_matrix.0
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+rm ${SDPB_TESTPREFIX}/io_tests/test/free_var_matrix.0
+touch ${SDPB_TESTPREFIX}/io_tests/test/free_var_matrix.0
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS free_var_matrix header"
@@ -329,12 +333,12 @@ else
     echo "FAIL free_var_matrix header"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-head -n 2 test/io_tests/test/free_var_matrix.0 > test/io_tests/test/free_var_matrix.0
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+head -n 2 ${SDPB_TESTPREFIX}/io_tests/test/free_var_matrix.0 > ${SDPB_TESTPREFIX}/io_tests/test/free_var_matrix.0
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS free_var_matrix data"
@@ -342,12 +346,12 @@ else
     echo "FAIL free_var_matrix data"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-chmod a-r test/io_tests/test/objectives
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+chmod a-r ${SDPB_TESTPREFIX}/io_tests/test/objectives
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS objectives read"
@@ -355,13 +359,13 @@ else
     echo "FAIL objectives read"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-rm test/io_tests/test/objectives
-touch test/io_tests/test/objectives
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+rm ${SDPB_TESTPREFIX}/io_tests/test/objectives
+touch ${SDPB_TESTPREFIX}/io_tests/test/objectives
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS objectives corrupted"
@@ -369,12 +373,12 @@ else
     echo "FAIL objectives corrupted"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-chmod a-r test/io_tests/test/primal_objective_c.0
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+chmod a-r ${SDPB_TESTPREFIX}/io_tests/test/primal_objective_c.0
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS primal_objective_c"
@@ -382,13 +386,13 @@ else
     echo "FAIL primal_objective_c"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-mpirun -n 1 ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 --writeSolution=x,y,X,Y
-chmod a-r test/io_tests/out/X_matrix_0.txt
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/out -o test/io_tests/out_new --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+mpirun -n 1 ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 --writeSolution=x,y,X,Y
+chmod a-r ${SDPB_TESTPREFIX}/io_tests/out/X_matrix_0.txt
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/out -o ${SDPB_TESTPREFIX}/io_tests/out_new --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS text checkpoint read"
@@ -396,14 +400,14 @@ else
     echo "FAIL text checkpoint read"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-mpirun -n 1 ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 --writeSolution=x,y,X,Y
-rm test/io_tests/out/X_matrix_0.txt
-touch test/io_tests/out/X_matrix_0.txt
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/out -o test/io_tests/out_new --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+mpirun -n 1 ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 --writeSolution=x,y,X,Y
+rm ${SDPB_TESTPREFIX}/io_tests/out/X_matrix_0.txt
+touch ${SDPB_TESTPREFIX}/io_tests/out/X_matrix_0.txt
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/out -o ${SDPB_TESTPREFIX}/io_tests/out_new --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS text checkpoint header"
@@ -411,13 +415,13 @@ else
     echo "FAIL text checkpoint header"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
-mkdir -p test/io_tests
-cp -r test/test test/io_tests
-mpirun -n 1 ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/ck -o test/io_tests/out --maxIterations=1 --verbosity=0 --writeSolution=x,y,X,Y
-head -n 2 test/io_tests/out/X_matrix_0.txt > test/io_tests/out/X_matrix_0.txt
-mpirun -n 1 --quiet ./build/sdpb --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s test/io_tests/test -c test/io_tests/out -o test/io_tests/out_new --maxIterations=1 --verbosity=0 2>/dev/null
+mkdir -p ${SDPB_TESTPREFIX}/io_tests
+cp -r ${SDPB_TESTPREFIX}/test ${SDPB_TESTPREFIX}/io_tests
+mpirun -n 1 ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/ck -o ${SDPB_TESTPREFIX}/io_tests/out --maxIterations=1 --verbosity=0 --writeSolution=x,y,X,Y
+head -n 2 ${SDPB_TESTPREFIX}/io_tests/out/X_matrix_0.txt > ${SDPB_TESTPREFIX}/io_tests/out/X_matrix_0.txt
+mpirun -n 1 --quiet ${SDPB_SDPB} --precision=1024 --noFinalCheckpoint --procsPerNode=1 -s ${SDPB_TESTPREFIX}/io_tests/test -c ${SDPB_TESTPREFIX}/io_tests/out -o ${SDPB_TESTPREFIX}/io_tests/out_new --maxIterations=1 --verbosity=0 2>/dev/null
 if [ $? != 0 ]
 then
     echo "PASS text checkpoint data"
@@ -425,6 +429,6 @@ else
     echo "FAIL text checkpoint data"
     result=1
 fi
-rm -rf test/io_tests
+rm -rf ${SDPB_TESTPREFIX}/io_tests
 
 exit $result


### PR DESCRIPTION
~~Containerize everything~~
This changeset adds an in-tree singularity container build. In the singularity directory executing `make` will build a container as well as run the test script. The default run command is sdpb with other utilities accessible with `singularity exec sdpb.sif <executable name> <args>`

Notes:
- The container build process is in two stages to speed source changes
- Haswell is the default build target for the OpenBLAS build. This can be modified by setting `BLAS_TARGET_ARCH` in the container
- only the contents of src/ are specified as make dependencies for the container
- `singularity test` uses the current directory as scratch space because the container is immutable after bootstrap
