### PR TITLE
added #include <limits> to compute_block_grid_mapping.cxx

### DIFF
--- a/src/compute_block_grid_mapping.cxx
+++ b/src/compute_block_grid_mapping.cxx
@@ -50,6 +50,7 @@
 #include <numeric>
 #include <algorithm>
 #include <stdexcept>
+#include <limits>
 
 #include <iostream>
 


### PR DESCRIPTION
On Arch Linux build fails with

` -> task in 'sdp_solve' failed with exit status 1 (run with -v to display more information)`

unless I include `limits` in `compute_block_grid_mapping.cxx`

I applied a commit on the tag 2.4.0. I'm not sure how to apply the same patch on the master branch, sorry if this creates some problems.