### PR TITLE
fix header references for boost 1.79.0

### DIFF
--- a/src/outer_limits/Outer_Parameters.hxx
+++ b/src/outer_limits/Outer_Parameters.hxx
@@ -5,6 +5,7 @@
 
 #include <El.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include <iostream>

--- a/src/pvm2functions/write_functions.cxx
+++ b/src/pvm2functions/write_functions.cxx
@@ -1,3 +1,5 @@
+#include <boost/filesystem/fstream.hpp>
+
 #include "../Boost_Float.hxx"
 #include "../sdp_convert.hxx"
 #include "../sdp_convert/write_vector.hxx"

--- a/src/sdp2functions/write_functions.cxx
+++ b/src/sdp2functions/write_functions.cxx
@@ -2,6 +2,7 @@
 #include "../sdp_convert/write_vector.hxx"
 
 #include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
 
 void write_functions(
   const boost::filesystem::path &output_path,

--- a/src/sdp_solve/Archive_Reader.hxx
+++ b/src/sdp_solve/Archive_Reader.hxx
@@ -4,7 +4,7 @@
 #include <archive_entry.h>
 
 #include <boost/filesystem.hpp>
-
+#include <boost/filesystem/fstream.hpp>
 #include <streambuf>
 #include <memory>
 #include <array>

--- a/src/sdp_solve/read_text_block.hxx
+++ b/src/sdp_solve/read_text_block.hxx
@@ -3,6 +3,7 @@
 #include <El.hpp>
 
 #include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
 
 inline void
 set_element(El::DistMatrix<El::BigFloat> &block, const int64_t &row,

--- a/src/spectrum/write_spectrum/write_file.cxx
+++ b/src/spectrum/write_spectrum/write_file.cxx
@@ -2,6 +2,7 @@
 #include "../../set_stream_precision.hxx"
 
 #include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
 
 void write_file(const boost::filesystem::path &output_path,
                 const std::vector<Zeros> &zeros_blocks)


### PR DESCRIPTION
Boost stopped including boost/filesystem/fstream.hpp in boost/filesystem.hpp
by default (boostorg/filesystem commit 266e1ac). This fixes missing headers.