### PR TITLE
Print memory usage

### DIFF
--- a/src/Timers.hxx
+++ b/src/Timers.hxx
@@ -24,15 +24,7 @@ struct Timers : public std::list<std::pair<std::string, Timer>>
   Timer &add_and_start(const std::string &name)
   {
     if(debug)
-      {
-        std::ifstream stat_file("/proc/self/statm");
-        if(stat_file.good())
-          {
-            std::string stats;
-            std::getline(stat_file, stats);
-            El::Output(El::mpi::Rank(), " ", name, " ", stats);
-          }
-      }
+      print_debug_info(name);
     emplace_back(name, Timer());
     return back().second;
   }
@@ -71,5 +63,107 @@ struct Timers : public std::list<std::pair<std::string, Timer>>
         throw std::runtime_error("Could not find timing for " + s);
       }
     return iter->second.elapsed_milliseconds();
+  }
+
+private:
+  static void print_debug_info(const std::string &name)
+  {
+    std::ostringstream ss;
+    ss << El::mpi::Rank() << " " << name << " ";
+    auto prefix = ss.str();
+
+    print_statm(prefix);
+
+    // /proc/meminfo is the same for all processes in node,
+    // so we print it only for rank 0.
+    // TODO: print meminfo for a first process of each node
+    // (makes sense if RAM is not distributed equally among the nodes)
+    if(El::mpi::Rank() == 0)
+      print_meminfo(prefix);
+  }
+
+  // TODO move to separate file
+
+  // /proc/self/statm displays the following quantities:
+  // size resident shared text lib data dt
+  // Each quantity is measured in pages;
+  // usually page size=4096B (you can check it by calling "getconf PAGESIZE")
+  static void print_statm(const std::string &prefix)
+  {
+    std::ifstream stat_file("/proc/self/statm");
+    if(stat_file.good())
+      {
+        std::string stats;
+        std::getline(stat_file, stats);
+        El::Output(prefix, stats);
+      }
+  }
+
+  // /proc/meminfo can be different on different OSs.
+  // Usually (e.g. on CentOS) it looks like
+  // MemTotal:       131189996 kB
+  // MemFree:        24211752 kB
+  // MemAvailable:   69487008 kB
+  // ...
+  // We print MemAvailable (RAM available for allocation)
+  // and MemUsed defined as MemUsed = MemTotal - MemAvailable.
+  // MemUsed is RAM that is occupied by all processes and cannot be released
+  // (i.e. it doesn't include cache)
+  static void print_meminfo(const std::string &prefix)
+  {
+    const char *proc_meminfo_path = "/proc/meminfo";
+    std::ifstream meminfo_file(proc_meminfo_path);
+
+    if(!meminfo_file.good())
+      return;
+
+    const char *mem_total_prefix = "MemTotal:";
+    const char *mem_available_prefix = "MemAvailable:";
+    size_t memTotalKB = 0;
+    size_t memAvailableKB = 0;
+    std::string line;
+    while(std::getline(meminfo_file, line))
+      {
+        std::istringstream iss(line);
+        std::string name;
+        size_t size;
+        std::string kB;
+        if(iss >> name >> size >> kB)
+          {
+            if(kB != "kB" && kB != "KB")
+              {
+                El::Output(proc_meminfo_path,
+                           ": expected \"kB\" at the end of line: ", line);
+                return;
+              }
+            if(name == mem_total_prefix)
+              memTotalKB = size;
+            else if(name == mem_available_prefix)
+              memAvailableKB = size;
+            if(memTotalKB > 0 && memAvailableKB > 0)
+              break;
+          }
+        else
+          {
+            El::Output(proc_meminfo_path, ": cannot parse line: ", line);
+            return;
+          }
+      }
+
+    if(memTotalKB == 0)
+      {
+        El::Output(proc_meminfo_path, ": ", mem_total_prefix, " not found");
+        return;
+      }
+    if(memAvailableKB == 0)
+      {
+        El::Output(proc_meminfo_path, ": ", mem_available_prefix,
+                   " not found");
+        return;
+      }
+    auto memAvailableGB = (double)memAvailableKB / 1024 / 1024;
+    auto memUsedGB = (double)(memTotalKB - memAvailableKB) / 1024 / 1024;
+    El::Output(prefix, "MemAvailable, GB: ", memAvailableGB);
+    El::Output(prefix, "MemUsed, GB: ", memUsedGB);
   }
 };

--- a/src/pvm2sdp/main.cxx
+++ b/src/pvm2sdp/main.cxx
@@ -20,6 +20,7 @@ int main(int argc, char **argv)
       int precision;
       std::vector<boost::filesystem::path> input_files;
       boost::filesystem::path output_path;
+      bool debug = false; // TODO read from command line
 
       parse_command_line(argc, argv, precision, input_files, output_path);
       El::gmp::SetPrecision(precision);
@@ -49,7 +50,7 @@ int main(int argc, char **argv)
         }
       write_sdpb_input_files(output_path, rank, num_blocks, command_arguments,
                              objective_const, dual_objective_b,
-                             dual_constraint_groups);
+                             dual_constraint_groups, debug);
     }
   catch(std::exception &e)
     {

--- a/src/sdp2input/main.cxx
+++ b/src/sdp2input/main.cxx
@@ -11,7 +11,7 @@ void write_output(const boost::filesystem::path &output_path,
                   const std::vector<El::BigFloat> &objectives,
                   const std::vector<El::BigFloat> &normalization,
                   const std::vector<Positive_Matrix_With_Prefactor> &matrices,
-                  Timers &timers);
+                  Timers &timers, bool debug);
 
 int main(int argc, char **argv)
 {
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
           command_arguments.emplace_back(argv[arg]);
         }
       write_output(output_path, command_arguments, objectives, normalization,
-                   matrices, timers);
+                   matrices, timers, debug);
       write_output_timer.stop();
       if(debug)
         {

--- a/src/sdp2input/write_output/write_output.cxx
+++ b/src/sdp2input/write_output/write_output.cxx
@@ -14,7 +14,7 @@ void write_output(const boost::filesystem::path &output_path,
                   const std::vector<El::BigFloat> &objectives,
                   const std::vector<El::BigFloat> &normalization,
                   const std::vector<Positive_Matrix_With_Prefactor> &matrices,
-                  Timers &timers)
+                  Timers &timers, bool debug)
 {
   auto &objectives_timer(timers.add_and_start("write_output.objectives"));
 
@@ -138,6 +138,6 @@ void write_output(const boost::filesystem::path &output_path,
   auto &write_timer(timers.add_and_start("write_output.write"));
   write_sdpb_input_files(output_path, rank, matrices.size(), command_arguments,
                          objective_const, dual_objective_b,
-                         dual_constraint_groups);
+                         dual_constraint_groups, debug);
   write_timer.stop();
 }

--- a/src/sdp_convert.hxx
+++ b/src/sdp_convert.hxx
@@ -13,5 +13,5 @@ void write_sdpb_input_files(
   const size_t &num_blocks, const std::vector<std::string> &command_arguments,
   const El::BigFloat &objective_const,
   const std::vector<El::BigFloat> &dual_objective_b,
-  const std::vector<Dual_Constraint_Group> &dual_constraint_groups);
-
+  const std::vector<Dual_Constraint_Group> &dual_constraint_groups,
+  bool debug);

--- a/src/sdp_convert/write_sdpb_input_files.cxx
+++ b/src/sdp_convert/write_sdpb_input_files.cxx
@@ -30,6 +30,10 @@ void write_free_var_matrix(std::ostream &output_stream,
                            const size_t &dual_objectives_b_size,
                            const Dual_Constraint_Group &group);
 
+void print_matrix_sizes(
+  const int &rank, const std::vector<El::BigFloat> &dual_objective_b,
+  const std::vector<Dual_Constraint_Group> &dual_constraint_groups);
+
 namespace
 {
   void archive_gzipped_file(const boost::filesystem::path &path,
@@ -48,7 +52,8 @@ void write_sdpb_input_files(
   const size_t &num_blocks, const std::vector<std::string> &command_arguments,
   const El::BigFloat &objective_const,
   const std::vector<El::BigFloat> &dual_objective_b,
-  const std::vector<Dual_Constraint_Group> &dual_constraint_groups)
+  const std::vector<Dual_Constraint_Group> &dual_constraint_groups,
+  const bool debug)
 {
   boost::filesystem::path temp_dir(output_path);
   temp_dir += "_temp";
@@ -96,6 +101,10 @@ void write_sdpb_input_files(
     }
   El::mpi::Reduce(block_file_sizes.data(), block_file_sizes.size(),
                   El::mpi::SUM, 0, El::mpi::COMM_WORLD);
+  if(debug)
+    {
+      print_matrix_sizes(rank, dual_objective_b, dual_constraint_groups);
+    }
   if(rank == 0)
     {
       Archive_Writer writer(output_path);
@@ -117,5 +126,110 @@ void write_sdpb_input_files(
           boost::filesystem::remove(block_path);
         }
       boost::filesystem::remove(temp_dir);
+    }
+}
+
+void print_matrix_sizes(
+  const int &rank, const std::vector<El::BigFloat> &dual_objective_b,
+  const std::vector<Dual_Constraint_Group> &dual_constraint_groups)
+{
+  if(rank == 0)
+    {
+      El::Output("---------------------");
+      El::Output("Matrix sizes and RAM estimates:");
+      El::Output("---------------------");
+    }
+
+  size_t N = dual_objective_b.size();
+  size_t my_P = 0; // P' for a given group
+
+  // Hereafter XXX_elements means number of nonzero elements in XXX
+  size_t my_constraint_matrix_elements = 0;
+  size_t my_bilinear_bases_elements = 0;
+  size_t my_bilinear_pairing_block_elements = 0;
+  size_t my_psd_elements = 0;
+  size_t my_schur_elements = 0;
+  for(auto &group : dual_constraint_groups)
+    {
+      my_P += group.constraint_constants.size();
+
+      my_constraint_matrix_elements += group.constraint_matrix.MemorySize();
+      my_bilinear_bases_elements += group.bilinear_bases[0].MemorySize()
+                                    + group.bilinear_bases[1].MemorySize();
+
+      // variables stored in Block_Info
+      size_t dimensions = group.dim;
+      size_t num_points = group.degree + 1; // see write_blocks()
+
+      // See Block_Info::schur_block_sizes()
+      size_t schur_width = num_points * dimensions * (dimensions + 1) / 2;
+      my_schur_elements += schur_width * schur_width;
+
+      // See Block_Info::bilinear_pairing_block_sizes()
+      // two blocks, each one has same size
+      size_t bilinear_pairing_block_width = num_points * dimensions;
+      my_bilinear_pairing_block_elements
+        += 2 * bilinear_pairing_block_width * bilinear_pairing_block_width;
+
+      // See Block_Info::psd_matrix_block_sizes()
+      // for each group we have two psd square matrix blocks, with width
+      // psd_even and psd_odd
+      auto psd_even = dimensions * ((num_points + 1) / 2);
+      auto psd_odd = dimensions * num_points - psd_even;
+      my_psd_elements += psd_even * psd_even + psd_odd * psd_odd;
+    }
+  if(my_P * N != my_constraint_matrix_elements)
+    {
+      El::LogicError("sum(P'*N) != #(B bands): P'=", my_P, ", N=", N,
+                     "#(B bands)=", my_constraint_matrix_elements);
+    }
+
+  // NB: Reduce should be called on all ranks, its result used only on rank 0!
+  auto reduce_sum = [](size_t item) {
+    return El::mpi::Reduce(item, El::mpi::SUM, 0, El::mpi::COMM_WORLD);
+  };
+
+  size_t B_matrix_elements = reduce_sum(my_constraint_matrix_elements);
+  size_t bilinear_pairing_block_elements
+    = reduce_sum(my_bilinear_pairing_block_elements);
+  size_t psd_blocks_elements = reduce_sum(my_psd_elements);
+  size_t schur_elements = reduce_sum(my_schur_elements);
+  size_t P = reduce_sum(my_P);
+  size_t bilinear_bases_elements = reduce_sum(my_bilinear_bases_elements);
+
+  if(rank == 0)
+    {
+      size_t big_float_bytes = El::BigFloat(1.1).SerializedSize();
+
+      size_t Q_matrix_size = N * N;
+      size_t total_no_Q = 2 * B_matrix_elements + 5 * psd_blocks_elements
+                          + 2 * schur_elements
+                          + 2 * bilinear_pairing_block_elements;
+
+      std::vector<std::pair<std::string, size_t>> sizes{
+        {"P (primal objective)", P},
+        {"N (dual objective)", N},
+        {"B matrix (PxN)", B_matrix_elements},
+        {"Q matrix (NxN)", Q_matrix_size},
+        {"Bilinear bases", bilinear_bases_elements},
+        {"Bilinear pairing blocks", bilinear_pairing_block_elements},
+        {"PSD blocks", psd_blocks_elements},
+        {"Schur (PxP block diagonal)", schur_elements},
+        {"Total (no Q) = 2#(B) + 5#(PSD) + 2#(S) + 2#(Bilinear pairing)",
+         total_no_Q},
+      };
+
+      El::Output("BigFloat, bytes: ", big_float_bytes);
+      for(auto &[key, value] : sizes)
+        {
+          El::Output(key, ", elements: ", value);
+          El::Output(key, ", bytes: ", value * big_float_bytes);
+        }
+      double GB_per_element = (double)big_float_bytes / 1024 / 1024 / 1024;
+      El::Output("Total RAM (no Q), GB: ", total_no_Q * GB_per_element);
+      El::Output("Q, GB: ", Q_matrix_size * GB_per_element);
+      El::Output("NB: Q is copied over each core group, i.e. "
+                 "(nodes*procsPerNode/procGranularity) times");
+      El::Output("---------------------");
     }
 }


### PR DESCRIPTION
in debug mode:
- `sdpb`: print `MemAvailable, GB` and `MemUsed, GB` (`= MemTotal - MemAvailable`) from `/proc/meminfo` at each timer start, e.g.:
```
0 run.objectives MemAvailable, GB: 62.6031
0 run.objectives MemUsed, GB: 188.866
```
- `sdp2input`: print matrix sizes and RAM estimates, e.g.:
```
---------------------
Matrix sizes and RAM estimates:
---------------------
BigFloat, bytes: 156
P (primal objective), elements: 195368
P (primal objective), bytes: 30477408
N (dual objective), elements: 9437
N (dual objective), bytes: 1472172
B matrix (PxN), elements: 1843687816
B matrix (PxN), bytes: 287615299296
Q matrix (NxN), elements: 89056969
Q matrix (NxN), bytes: 13892887164
Bilinear bases, elements: 9045327
Bilinear bases, bytes: 1411071012
Bilinear pairing blocks, elements: 72157126
Bilinear pairing blocks, bytes: 11256511656
PSD blocks, elements: 18039573
PSD blocks, bytes: 2814173388
Schur (PxP block diagonal), elements: 121897852
Schur (PxP block diagonal), bytes: 19016064912
Total (no Q) = 2#(B) + 5#(PSD) + 2#(S) + 2#(Bilinear pairing), elements: 4165683453
Total (no Q) = 2#(B) + 5#(PSD) + 2#(S) + 2#(Bilinear pairing), bytes: 649846618668
Total RAM (no Q), GB: 605.217
Q, GB: 12.9388
NB: Q is copied over each core group, i.e. (nodes*procsPerNode/procGranularity) times
---------------------
```