### PR TITLE
Integration tests improvements

### DIFF
--- a/test/src/integration_tests/cases/end-to-end.test.cxx
+++ b/test/src/integration_tests/cases/end-to-end.test.cxx
@@ -12,8 +12,8 @@ namespace
 {
   void end_to_end_test(const std::string &name,
                        const std::string &default_sdpb_args, int num_procs,
-                       int precision, int sdp2input_final_precision,
-                       int sdpb_final_precision,
+                       int precision, int sdp_zip_diff_precision,
+                       int sdpb_output_diff_precision,
                        const std::vector<std::string> &out_txt_keys = {})
   {
     Test_Util::Test_Case_Runner runner(name);
@@ -34,10 +34,10 @@ namespace
         .mpi_run({"build/sdp2input"}, args, num_procs);
 
       // sdp2input runs with --precision=<precision>
-      // We check test output up to lower precision=<sdp2input_final_precision>
+      // We check test output up to lower precision=<sdp_zip_diff_precision>
       // in order to neglect unimportant rounding errors
       Test_Util::REQUIRE_Equal::diff_sdp_zip(
-        sdp_zip, sdp_orig_zip, sdp2input_final_precision,
+        sdp_zip, sdp_orig_zip, precision, sdp_zip_diff_precision,
         runner.create_nested("sdp2input/diff"));
     }
 
@@ -53,11 +53,11 @@ namespace
         .mpi_run({"build/sdpb", default_sdpb_args}, args, num_procs);
 
       // SDPB runs with --precision=<precision>
-      // We check test output up to lower precision=<sdpb_final_precision>
+      // We check test output up to lower precision=<sdpb_output_diff_precision>
       // in order to neglect unimportant rounding errors
       Test_Util::REQUIRE_Equal::diff_sdpb_output_dir(
-        output_dir / "out", data_dir / "out", sdpb_final_precision, {},
-        out_txt_keys);
+        output_dir / "out", data_dir / "out", precision,
+        sdpb_output_diff_precision, {}, out_txt_keys);
     }
   }
 }
@@ -70,7 +70,7 @@ TEST_CASE("end-to-end_tests")
        "depending on GMP/MPFR version etc");
   int num_procs = 6;
   int precision = 768;
-  int sdp2input_final_precision = 608;
+  int sdp_zip_diff_precision = 608;
   std::string name = "end-to-end_tests";
 
   SECTION("SingletScalar_cT_test_nmax6/primal_dual_optimal")
@@ -88,9 +88,9 @@ TEST_CASE("end-to-end_tests")
         "--infeasibleCenteringParameter 0.3 --stepLengthReduction 0.7 "
         "--maxComplementarity 1.0e100 --maxIterations 1000 --verbosity 1 "
         "--procGranularity 1 --writeSolution y";
-    int sdpb_final_precision = 600;
+    int sdpb_output_diff_precision = 600;
     end_to_end_test(name, default_sdpb_args, num_procs, precision,
-                    sdp2input_final_precision, sdpb_final_precision);
+                    sdp_zip_diff_precision, sdpb_output_diff_precision);
   }
 
   SECTION("SingletScalarAllowed_test_nmax6")
@@ -108,7 +108,7 @@ TEST_CASE("end-to-end_tests")
         "--maxComplementarity 1.0e100 --maxIterations 1000 --verbosity 1 "
         "--procGranularity 1 --writeSolution y "
         "--detectPrimalFeasibleJump --detectDualFeasibleJump";
-    int sdpb_final_precision = 610;
+    int sdpb_output_diff_precision = 610;
 
     SECTION("primal_feasible_jump")
     {
@@ -118,7 +118,7 @@ TEST_CASE("end-to-end_tests")
         = {"terminateReason", "primalObjective", "dualObjective", "dualityGap",
            "dualError"};
       end_to_end_test(name, default_sdpb_args, num_procs, precision,
-                      sdp2input_final_precision, sdpb_final_precision,
+                      sdp_zip_diff_precision, sdpb_output_diff_precision,
                       out_txt_keys);
     }
     SECTION("dual_feasible_jump")
@@ -129,7 +129,7 @@ TEST_CASE("end-to-end_tests")
         = {"terminateReason", "primalObjective", "dualObjective", "dualityGap",
            "primalError"};
       end_to_end_test(name, default_sdpb_args, num_procs, precision,
-                      sdp2input_final_precision, sdpb_final_precision,
+                      sdp_zip_diff_precision, sdpb_output_diff_precision,
                       out_txt_keys);
     }
   }

--- a/test/src/integration_tests/cases/outer_limits.test.cxx
+++ b/test/src/integration_tests/cases/outer_limits.test.cxx
@@ -29,5 +29,5 @@ TEST_CASE("outer_limits")
 
   auto out = output_dir / "toy_functions_out.json";
   auto out_orig = data_dir / "toy_functions_out_orig.json";
-  Test_Util::REQUIRE_Equal::diff_outer_limits(out, out_orig, 128);
+  Test_Util::REQUIRE_Equal::diff_outer_limits(out, out_orig, 128, 128);
 }

--- a/test/src/integration_tests/cases/pvm2sdp.test.cxx
+++ b/test/src/integration_tests/cases/pvm2sdp.test.cxx
@@ -21,7 +21,7 @@ TEST_CASE("pvm2sdp")
 
     auto output_orig = (Test_Config::test_data_dir / "sdp.zip").string();
 
-    Test_Util::REQUIRE_Equal::diff_sdp_zip(output, output_orig, 1024,
+    Test_Util::REQUIRE_Equal::diff_sdp_zip(output, output_orig, 1024, 1024,
                                            runner.create_nested("diff"));
   }
 

--- a/test/src/integration_tests/cases/sdp2input.test.cxx
+++ b/test/src/integration_tests/cases/sdp2input.test.cxx
@@ -28,7 +28,7 @@ TEST_CASE("sdp2input")
 
         runner.create_nested("run").mpi_run({"build/sdp2input"}, args);
 
-        Test_Util::REQUIRE_Equal::diff_sdp_zip(sdp_zip, sdp_orig, 1024,
+        Test_Util::REQUIRE_Equal::diff_sdp_zip(sdp_zip, sdp_orig, 512,
                                                runner.create_nested("diff"));
 
         REQUIRE(boost::filesystem::file_size(sdp_zip + ".profiling.0") > 0);

--- a/test/src/integration_tests/cases/sdp2input.test.cxx
+++ b/test/src/integration_tests/cases/sdp2input.test.cxx
@@ -28,7 +28,7 @@ TEST_CASE("sdp2input")
 
         runner.create_nested("run").mpi_run({"build/sdp2input"}, args);
 
-        Test_Util::REQUIRE_Equal::diff_sdp_zip(sdp_zip, sdp_orig, 512,
+        Test_Util::REQUIRE_Equal::diff_sdp_zip(sdp_zip, sdp_orig, 512, 512,
                                                runner.create_nested("diff"));
 
         REQUIRE(boost::filesystem::file_size(sdp_zip + ".profiling.0") > 0);

--- a/test/src/integration_tests/cases/sdpb.test.cxx
+++ b/test/src/integration_tests/cases/sdpb.test.cxx
@@ -27,8 +27,8 @@ TEST_CASE("sdpb")
     args["--checkpointDir"] = (runner.output_dir / "ck").string();
     args["--outDir"] = (runner.output_dir / "out").string();
     args["--procsPerNode"] = std::to_string(num_procs);
-    runner.mpi_run({"build/sdpb"}, args, num_procs,
-                   required_exit_code, required_error_msg);
+    runner.mpi_run({"build/sdpb"}, args, num_procs, required_exit_code,
+                   required_error_msg);
   };
 
   // create file with readonly premissions
@@ -46,7 +46,7 @@ TEST_CASE("sdpb")
     auto args = default_args;
     run_sdpb_set_out_ck_dirs(runner.create_nested("run"), args, 1);
     Test_Util::REQUIRE_Equal::diff_sdpb_output_dir(
-      args["--outDir"], data_dir / "test_out_orig", 1024);
+      args["--outDir"], data_dir / "test_out_orig", 1024, 1024);
   }
 
   SECTION("io_tests")

--- a/test/src/integration_tests/cases/spectrum.test.cxx
+++ b/test/src/integration_tests/cases/spectrum.test.cxx
@@ -22,5 +22,5 @@ TEST_CASE("spectrum")
 
   auto out = output_dir / "spectrum.json";
   auto out_orig = data_dir / "spectrum_orig.json";
-  Test_Util::REQUIRE_Equal::diff_spectrum(out, out_orig, 1024);
+  Test_Util::REQUIRE_Equal::diff_spectrum(out, out_orig, 1024, 1024);
 }

--- a/test/src/integration_tests/util/Float.cxx
+++ b/test/src/integration_tests/util/Float.cxx
@@ -1,13 +1,19 @@
 #include "Float.hxx"
 
-Float_Binary_Precision::Float_Binary_Precision(unsigned int binary_precision)
-    : old_decimal_precision(Float::default_precision())
+#include "diff.hxx"
+
+Float_Binary_Precision::Float_Binary_Precision(unsigned int binary_precision,
+                                               unsigned int diff_precision)
+    : old_decimal_precision(Float::default_precision()),
+      old_diff_precision(diff_precision)
 {
   unsigned int decimal_precision
     = std::ceil(binary_precision * std::log10(2.0)) + 1;
   Float::default_precision(decimal_precision);
+  Test_Util::REQUIRE_Equal::diff_precision = diff_precision;
 }
 Float_Binary_Precision::~Float_Binary_Precision()
 {
   Float::default_precision(old_decimal_precision);
+  Test_Util::REQUIRE_Equal::diff_precision = old_diff_precision;
 }

--- a/test/src/integration_tests/util/Float.cxx
+++ b/test/src/integration_tests/util/Float.cxx
@@ -2,18 +2,34 @@
 
 #include "diff.hxx"
 
+#include <El.hpp>
+
+namespace
+{
+  // Copied from El::gmp::SetPrecision()
+  // We remove MPI code and
+  // allow for changing precision many times (at our own risk)
+  // - this is needed for our tests.
+  void El_gmp_set_precision(mp_bitcnt_t prec)
+  {
+    El::gmp::num_limbs
+      = (std::max(prec, static_cast<mp_bitcnt_t>(53)) + 2 * GMP_NUMB_BITS - 1)
+          / GMP_NUMB_BITS
+        + 1;
+    mpf_set_default_prec(prec);
+  }
+}
+
 Float_Binary_Precision::Float_Binary_Precision(unsigned int binary_precision,
                                                unsigned int diff_precision)
-    : old_decimal_precision(Float::default_precision()),
+    : old_binary_precision(binary_precision),
       old_diff_precision(diff_precision)
 {
-  unsigned int decimal_precision
-    = std::ceil(binary_precision * std::log10(2.0)) + 1;
-  Float::default_precision(decimal_precision);
+  El_gmp_set_precision(binary_precision);
   Test_Util::REQUIRE_Equal::diff_precision = diff_precision;
 }
 Float_Binary_Precision::~Float_Binary_Precision()
 {
-  Float::default_precision(old_decimal_precision);
+  El_gmp_set_precision(old_binary_precision);
   Test_Util::REQUIRE_Equal::diff_precision = old_diff_precision;
 }

--- a/test/src/integration_tests/util/Float.hxx
+++ b/test/src/integration_tests/util/Float.hxx
@@ -8,11 +8,14 @@ using Float_Vector = std::vector<Float>;
 using Float_Matrix = std::vector<Float_Vector>;
 
 // Temporarily sets MPFR precision
+// and precision used for Float comparison
 struct Float_Binary_Precision : boost::noncopyable
 {
-  explicit Float_Binary_Precision(unsigned int binary_precision);
+  explicit Float_Binary_Precision(unsigned int binary_precision,
+                                  unsigned int diff_precision);
   ~Float_Binary_Precision();
 
 private:
   unsigned int old_decimal_precision;
+  unsigned int old_diff_precision;
 };

--- a/test/src/integration_tests/util/Float.hxx
+++ b/test/src/integration_tests/util/Float.hxx
@@ -6,7 +6,7 @@
 
 using Float = El::BigFloat;
 using Float_Vector = std::vector<Float>;
-using Float_Matrix = std::vector<Float_Vector>;
+using Float_Matrix = El::Matrix<Float>;
 
 // Temporarily sets El::BigFloat precision
 // and precision used in BigFloat comparison

--- a/test/src/integration_tests/util/Float.hxx
+++ b/test/src/integration_tests/util/Float.hxx
@@ -1,14 +1,15 @@
 #pragma once
 
-#include <boost/multiprecision/mpfr.hpp>
+#include <El.hpp>
+#include <boost/noncopyable.hpp>
 #include <vector>
 
-using Float = boost::multiprecision::mpfr_float;
+using Float = El::BigFloat;
 using Float_Vector = std::vector<Float>;
 using Float_Matrix = std::vector<Float_Vector>;
 
-// Temporarily sets MPFR precision
-// and precision used for Float comparison
+// Temporarily sets El::BigFloat precision
+// and precision used in BigFloat comparison
 struct Float_Binary_Precision : boost::noncopyable
 {
   explicit Float_Binary_Precision(unsigned int binary_precision,
@@ -16,6 +17,6 @@ struct Float_Binary_Precision : boost::noncopyable
   ~Float_Binary_Precision();
 
 private:
-  unsigned int old_decimal_precision;
+  unsigned int old_binary_precision;
   unsigned int old_diff_precision;
 };

--- a/test/src/integration_tests/util/Test_Case_Runner.cxx
+++ b/test/src/integration_tests/util/Test_Case_Runner.cxx
@@ -112,7 +112,26 @@ namespace Test_Util
     os_stdout << stderr_string;
     os_stderr << stderr_string;
 
-    REQUIRE(exit_code == required_exit_code);
+    CAPTURE(exit_code);
+    CAPTURE(required_exit_code);
+    CAPTURE(stderr_string);
+    if(required_exit_code == 0)
+      {
+        REQUIRE(exit_code == 0);
+      }
+    else
+      {
+        REQUIRE(exit_code != 0);
+        if(exit_code != required_exit_code)
+          {
+            // We can get, e.g., code 137 from srun,
+            // when MPI process exits with code 1.
+            // Test should not fail in this case,
+            // so we only print warning.
+            WARN("Expected exit code " << exit_code << ", got "
+                                       << required_exit_code);
+          }
+      }
     if(required_exit_code != 0 && !required_error_msg.empty())
       {
         CAPTURE(required_error_msg);
@@ -149,8 +168,7 @@ namespace Test_Util
   {
     std::vector<std::string> args_with_mpi(args);
     args_with_mpi.insert(args_with_mpi.begin(), build_mpirun_prefix(numProcs));
-    run(args_with_mpi, named_args, required_exit_code,
-        required_error_msg);
+    run(args_with_mpi, named_args, required_exit_code, required_error_msg);
   }
 
   boost::filesystem::path Test_Case_Runner::unzip_to_temp_dir(

--- a/test/src/integration_tests/util/diff.hxx
+++ b/test/src/integration_tests/util/diff.hxx
@@ -6,6 +6,12 @@
 #include <catch2/catch_amalgamated.hpp>
 #include <boost/filesystem.hpp>
 
+#define DIFF(a, b)                                                            \
+  {                                                                           \
+    INFO("DIFF(" << #a << ", " << #b << ")");                                 \
+    diff(a, b);                                                               \
+  }
+
 // Functions that REQUIRE equality of given files or folders.
 // NB: we call REQUIRE() inside these functions,
 // because otherwise useful CAPTURE() information will be lost
@@ -65,8 +71,8 @@ namespace Test_Util::REQUIRE_Equal
   inline void diff(const std::pair<T1, T2> &a, const std::pair<T1, T2> &b)
   {
     INFO("diff std::pair");
-    diff(a.first, b.first);
-    diff(a.second, b.second);
+    DIFF(a.first, b.first);
+    DIFF(a.second, b.second);
   }
   template <class T>
   inline void diff(const std::vector<T> &a, const std::vector<T> &b)
@@ -76,7 +82,7 @@ namespace Test_Util::REQUIRE_Equal
     for(size_t i = 0; i < a.size(); ++i)
       {
         CAPTURE(i);
-        diff(a[i], b[i]);
+        DIFF(a[i], b[i]);
       }
   }
   template <class T>
@@ -90,7 +96,7 @@ namespace Test_Util::REQUIRE_Equal
         {
           CAPTURE(row);
           CAPTURE(col);
-          diff(a.Get(row, col), b.Get(row, col));
+          DIFF(a.Get(row, col), b.Get(row, col));
         }
   }
 }

--- a/test/src/integration_tests/util/diff.hxx
+++ b/test/src/integration_tests/util/diff.hxx
@@ -11,6 +11,8 @@
 // because otherwise useful CAPTURE() information will be lost
 namespace Test_Util::REQUIRE_Equal
 {
+  inline unsigned int diff_precision;
+
   // Compare SDPB output directories by content.
   // filenames: which files to compare (by default - all)
   // out_txt_keys: which keys compare in out.txt
@@ -18,29 +20,42 @@ namespace Test_Util::REQUIRE_Equal
   // Floating-point numbers are rounded to binary_precision
   void diff_sdpb_output_dir(const boost::filesystem::path &a_out_dir,
                             const boost::filesystem::path &b_out_dir,
-                            unsigned int binary_precision,
+                            unsigned int input_precision,
+                            unsigned int diff_precision,
                             const std::vector<std::string> &filenames = {},
                             const std::vector<std::string> &out_txt_keys = {});
 
   void diff_sdp_zip(const boost::filesystem::path &a_sdp_zip,
                     const boost::filesystem::path &b_sdp_zip,
-                    unsigned int binary_precision, Test_Case_Runner runner);
+                    unsigned int input_precision, unsigned int diff_precision,
+                    Test_Case_Runner runner);
 
-  void diff_outer_limits(const boost::filesystem::path &a_json,
-                         const boost::filesystem::path &b_json,
-                         unsigned int binary_precision);
+  void
+  diff_outer_limits(const boost::filesystem::path &a_json,
+                    const boost::filesystem::path &b_json,
+                    unsigned int input_precision, unsigned int diff_precision);
 
-  void diff_spectrum(const boost::filesystem::path &a_json,
-                     const boost::filesystem::path &b_json,
-                     unsigned int binary_precision);
+  void
+  diff_spectrum(const boost::filesystem::path &a_json,
+                const boost::filesystem::path &b_json,
+                unsigned int input_precision, unsigned int diff_precision);
 
   inline void diff(int a, int b) { REQUIRE(a == b); }
   inline void diff(const Float &a, const Float &b)
   {
-    // a and b will not be printed with all digits,
-    // so we display also their (sometimes small) difference.
+    if(a == b)
+      return;
+
+    CAPTURE(a);
+    CAPTURE(b);
     CAPTURE(a - b);
-    REQUIRE(a == b);
+
+    CAPTURE(diff_precision);
+    REQUIRE(diff_precision > 0);
+
+    auto eps = pow(Float(2.0), -Float(diff_precision));
+    CAPTURE(eps);
+    REQUIRE(abs(a - b) < eps * (abs(a) + abs(b)));
   }
   inline void diff(const std::string &a, const std::string &b)
   {

--- a/test/src/integration_tests/util/diff.hxx
+++ b/test/src/integration_tests/util/diff.hxx
@@ -53,9 +53,9 @@ namespace Test_Util::REQUIRE_Equal
     CAPTURE(diff_precision);
     REQUIRE(diff_precision > 0);
 
-    auto eps = pow(Float(2.0), -Float(diff_precision));
+    auto eps = Float(1) >>= diff_precision; // 2^{-precision}
     CAPTURE(eps);
-    REQUIRE(abs(a - b) < eps * (abs(a) + abs(b)));
+    REQUIRE(Abs(a - b) < eps * (Abs(a) + Abs(b)));
   }
   inline void diff(const std::string &a, const std::string &b)
   {

--- a/test/src/integration_tests/util/diff.hxx
+++ b/test/src/integration_tests/util/diff.hxx
@@ -64,17 +64,33 @@ namespace Test_Util::REQUIRE_Equal
   template <class T1, class T2>
   inline void diff(const std::pair<T1, T2> &a, const std::pair<T1, T2> &b)
   {
+    INFO("diff std::pair");
     diff(a.first, b.first);
     diff(a.second, b.second);
   }
   template <class T>
   inline void diff(const std::vector<T> &a, const std::vector<T> &b)
   {
+    INFO("diff std::vector");
     REQUIRE(a.size() == b.size());
     for(size_t i = 0; i < a.size(); ++i)
       {
         CAPTURE(i);
         diff(a[i], b[i]);
       }
+  }
+  template <class T>
+  inline void diff(const El::Matrix<T> &a, const El::Matrix<T> &b)
+  {
+    INFO("diff El::Matrix");
+    REQUIRE(a.Height() == b.Height());
+    REQUIRE(a.Width() == b.Width());
+    for(int row = 0; row < a.Height(); ++row)
+      for(int col = 0; col < a.Width(); ++col)
+        {
+          CAPTURE(row);
+          CAPTURE(col);
+          diff(a.Get(row, col), b.Get(row, col));
+        }
   }
 }

--- a/test/src/integration_tests/util/diff_outer_limits.cxx
+++ b/test/src/integration_tests/util/diff_outer_limits.cxx
@@ -43,14 +43,15 @@ namespace
 // Implementation
 namespace Test_Util::REQUIRE_Equal
 {
-  void diff_outer_limits(const boost::filesystem::path &a_json,
-                         const boost::filesystem::path &b_json,
-                         unsigned int binary_precision)
+  void
+  diff_outer_limits(const boost::filesystem::path &a_json,
+                    const boost::filesystem::path &b_json,
+                    unsigned int input_precision, unsigned int diff_precision)
   {
     INFO("diff outer_limits output");
     CAPTURE(a_json);
     CAPTURE(b_json);
-    Float_Binary_Precision prec(binary_precision);
+    Float_Binary_Precision prec(input_precision, diff_precision);
     Parse_Outer_Limits_Json a(a_json);
     Parse_Outer_Limits_Json b(b_json);
     diff(a.optimal, b.optimal);

--- a/test/src/integration_tests/util/diff_outer_limits.cxx
+++ b/test/src/integration_tests/util/diff_outer_limits.cxx
@@ -20,10 +20,8 @@ namespace
     Float optimal;
     Float_Vector y;
     std::vector<std::pair<std::string, std::string>> options;
-    explicit Parse_Outer_Limits_Json(const boost::filesystem::path &path,
-                                     unsigned int binary_precision)
+    explicit Parse_Outer_Limits_Json(const boost::filesystem::path &path)
     {
-      Float_Binary_Precision _(binary_precision);
       CAPTURE(path);
       REQUIRE(exists(path));
       boost::filesystem::ifstream is(path);
@@ -52,8 +50,9 @@ namespace Test_Util::REQUIRE_Equal
     INFO("diff outer_limits output");
     CAPTURE(a_json);
     CAPTURE(b_json);
-    Parse_Outer_Limits_Json a(a_json, binary_precision);
-    Parse_Outer_Limits_Json b(b_json, binary_precision);
+    Float_Binary_Precision prec(binary_precision);
+    Parse_Outer_Limits_Json a(a_json);
+    Parse_Outer_Limits_Json b(b_json);
     diff(a.optimal, b.optimal);
     diff(a.y, b.y);
     diff(a.options, b.options);

--- a/test/src/integration_tests/util/diff_outer_limits.cxx
+++ b/test/src/integration_tests/util/diff_outer_limits.cxx
@@ -54,8 +54,8 @@ namespace Test_Util::REQUIRE_Equal
     Float_Binary_Precision prec(input_precision, diff_precision);
     Parse_Outer_Limits_Json a(a_json);
     Parse_Outer_Limits_Json b(b_json);
-    diff(a.optimal, b.optimal);
-    diff(a.y, b.y);
-    diff(a.options, b.options);
+    DIFF(a.optimal, b.optimal);
+    DIFF(a.y, b.y);
+    DIFF(a.options, b.options);
   }
 }

--- a/test/src/integration_tests/util/diff_sdp_zip.cxx
+++ b/test/src/integration_tests/util/diff_sdp_zip.cxx
@@ -138,12 +138,13 @@ namespace Test_Util::REQUIRE_Equal
 {
   void diff_sdp_zip(const boost::filesystem::path &a_sdp_zip,
                     const boost::filesystem::path &b_sdp_zip,
-                    unsigned int binary_precision, Test_Case_Runner runner)
+                    unsigned int input_precision, unsigned int diff_precision,
+                    Test_Case_Runner runner)
   {
     INFO("diff sdp.zip files");
     CAPTURE(a_sdp_zip);
     CAPTURE(b_sdp_zip);
-    Float_Binary_Precision prec(binary_precision);
+    Float_Binary_Precision prec(input_precision, diff_precision);
     auto a = runner.unzip_to_temp_dir(a_sdp_zip);
     auto b = runner.unzip_to_temp_dir(b_sdp_zip);
     diff_control_json(a / "control.json", b / "control.json");

--- a/test/src/integration_tests/util/diff_sdp_zip.cxx
+++ b/test/src/integration_tests/util/diff_sdp_zip.cxx
@@ -37,12 +37,10 @@ namespace
   {
     Float constant;
     std::vector<Float> b;
-    Parse_Objectives_Json(const boost::filesystem::path &path,
-                          unsigned int binary_precision)
+    explicit Parse_Objectives_Json(const boost::filesystem::path &path)
     {
       CAPTURE(path);
       REQUIRE(exists(path));
-      Float_Binary_Precision _(binary_precision);
       boost::filesystem::ifstream is(path);
       rapidjson::IStreamWrapper wrapper(is);
       rapidjson::Document document;
@@ -62,12 +60,10 @@ namespace
     Float_Vector c;
     Float_Matrix B;
 
-    Parse_Block_Json(const boost::filesystem::path &path,
-                     unsigned int binary_precision)
+    explicit Parse_Block_Json(const boost::filesystem::path &path)
     {
       CAPTURE(path);
       REQUIRE(exists(path));
-      Float_Binary_Precision _(binary_precision);
       boost::filesystem::ifstream is(path);
       rapidjson::IStreamWrapper wrapper(is);
       rapidjson::Document document;
@@ -102,27 +98,25 @@ namespace
   }
 
   void diff_objectives_json(const boost::filesystem::path &a_objectives_json,
-                            const boost::filesystem::path &b_objectives_json,
-                            unsigned int binary_precision)
+                            const boost::filesystem::path &b_objectives_json)
   {
     CAPTURE(a_objectives_json);
     CAPTURE(b_objectives_json);
-    Parse_Objectives_Json a(a_objectives_json, binary_precision);
-    Parse_Objectives_Json b(b_objectives_json, binary_precision);
+    Parse_Objectives_Json a(a_objectives_json);
+    Parse_Objectives_Json b(b_objectives_json);
     diff(a.constant, b.constant);
     diff(a.b, b.b);
   }
 
   void diff_block_json(const boost::filesystem::path &a_block_json,
-                       const boost::filesystem::path &b_block_json,
-                       unsigned int binary_precision)
+                       const boost::filesystem::path &b_block_json)
 
   {
     INFO("diff_block_json");
     CAPTURE(a_block_json);
     CAPTURE(b_block_json);
-    Parse_Block_Json a_block(a_block_json, binary_precision);
-    Parse_Block_Json b_block(b_block_json, binary_precision);
+    Parse_Block_Json a_block(a_block_json);
+    Parse_Block_Json b_block(b_block_json);
 
     INFO("diff dim");
     diff(a_block.dim, b_block.dim);
@@ -149,16 +143,16 @@ namespace Test_Util::REQUIRE_Equal
     INFO("diff sdp.zip files");
     CAPTURE(a_sdp_zip);
     CAPTURE(b_sdp_zip);
+    Float_Binary_Precision prec(binary_precision);
     auto a = runner.unzip_to_temp_dir(a_sdp_zip);
     auto b = runner.unzip_to_temp_dir(b_sdp_zip);
     diff_control_json(a / "control.json", b / "control.json");
-    diff_objectives_json(a / "objectives.json", b / "objectives.json",
-                         binary_precision);
+    diff_objectives_json(a / "objectives.json", b / "objectives.json");
     Parse_Control_Json control(a / "control.json");
     for(int i = 0; i < control.num_blocks; ++i)
       {
         auto block_name = "block_" + std::to_string(i) + ".json";
-        diff_block_json(a / block_name, b / block_name, binary_precision);
+        diff_block_json(a / block_name, b / block_name);
       }
   }
 }

--- a/test/src/integration_tests/util/diff_sdp_zip.cxx
+++ b/test/src/integration_tests/util/diff_sdp_zip.cxx
@@ -92,7 +92,7 @@ namespace
     CAPTURE(b_control_json);
     Parse_Control_Json a(a_control_json);
     Parse_Control_Json b(b_control_json);
-    diff(a.num_blocks, b.num_blocks);
+    DIFF(a.num_blocks, b.num_blocks);
     // ignore "command", since it's unimportant:
     // diff(a.command, b.command);
   }
@@ -104,8 +104,8 @@ namespace
     CAPTURE(b_objectives_json);
     Parse_Objectives_Json a(a_objectives_json);
     Parse_Objectives_Json b(b_objectives_json);
-    diff(a.constant, b.constant);
-    diff(a.b, b.b);
+    DIFF(a.constant, b.constant);
+    DIFF(a.b, b.b);
   }
 
   void diff_block_json(const boost::filesystem::path &a_block_json,
@@ -118,18 +118,12 @@ namespace
     Parse_Block_Json a_block(a_block_json);
     Parse_Block_Json b_block(b_block_json);
 
-    INFO("diff dim");
-    diff(a_block.dim, b_block.dim);
-    INFO("diff num_points");
-    diff(a_block.num_points, b_block.num_points);
-    INFO("diff bilinear_bases_even");
-    diff(a_block.bilinear_bases_even, b_block.bilinear_bases_even);
-    INFO("diff bilinear_bases_odd");
-    diff(a_block.bilinear_bases_odd, b_block.bilinear_bases_odd);
-    INFO("diff constraint vector c");
-    diff(a_block.c, b_block.c);
-    INFO("diff constraint matrix B");
-    diff(a_block.B, b_block.B);
+    DIFF(a_block.dim, b_block.dim);
+    DIFF(a_block.num_points, b_block.num_points);
+    DIFF(a_block.bilinear_bases_even, b_block.bilinear_bases_even);
+    DIFF(a_block.bilinear_bases_odd, b_block.bilinear_bases_odd);
+    DIFF(a_block.c, b_block.c);
+    DIFF(a_block.B, b_block.B);
   }
 }
 

--- a/test/src/integration_tests/util/diff_sdpb_out.cxx
+++ b/test/src/integration_tests/util/diff_sdpb_out.cxx
@@ -92,9 +92,9 @@ namespace
     CAPTURE(b_matrix_txt);
     Parse_Matrix_Txt a(a_matrix_txt);
     Parse_Matrix_Txt b(b_matrix_txt);
-    diff(a.height, b.height);
-    diff(a.width, b.width);
-    diff(a.elements, b.elements);
+    DIFF(a.height, b.height);
+    DIFF(a.width, b.width);
+    DIFF(a.elements, b.elements);
   }
 
   // Compare out.txt
@@ -131,7 +131,7 @@ namespace
         REQUIRE(a_map.find(key) != a_map.end());
         REQUIRE(b_map.find(key) != b_map.end());
 
-        diff(a_map[key], b_map[key]);
+        DIFF(a_map[key], b_map[key]);
       }
   }
 }

--- a/test/src/integration_tests/util/diff_sdpb_out.cxx
+++ b/test/src/integration_tests/util/diff_sdpb_out.cxx
@@ -15,11 +15,8 @@ namespace
     int height;
     int width;
     Float_Vector elements;
-    Parse_Matrix_Txt(const boost::filesystem::path &path,
-                     unsigned int binary_precision)
+    explicit Parse_Matrix_Txt(const boost::filesystem::path &path)
     {
-      Float_Binary_Precision _(binary_precision);
-
       CAPTURE(path);
       REQUIRE(is_regular_file(path));
       boost::filesystem::ifstream is(path);
@@ -47,11 +44,8 @@ namespace
     std::string terminate_reason;
     std::map<std::string, Float> float_map;
 
-    Parse_Sdpb_Out_Txt(const boost::filesystem::path &path,
-                       unsigned int binary_precision)
+    explicit Parse_Sdpb_Out_Txt(const boost::filesystem::path &path)
     {
-      Float_Binary_Precision _(binary_precision);
-
       CAPTURE(path);
       REQUIRE(is_regular_file(path));
       boost::filesystem::ifstream is(path);
@@ -92,13 +86,12 @@ namespace
   // Compare matrices written by SDPB save_solution() method,
   // e.g. y.txt or X.txt
   void diff_matrix_txt(const boost::filesystem::path &a_matrix_txt,
-                       const boost::filesystem::path &b_matrix_txt,
-                       unsigned int binary_precision)
+                       const boost::filesystem::path &b_matrix_txt)
   {
     CAPTURE(a_matrix_txt);
     CAPTURE(b_matrix_txt);
-    Parse_Matrix_Txt a(a_matrix_txt, binary_precision);
-    Parse_Matrix_Txt b(b_matrix_txt, binary_precision);
+    Parse_Matrix_Txt a(a_matrix_txt);
+    Parse_Matrix_Txt b(b_matrix_txt);
     diff(a.height, b.height);
     diff(a.width, b.width);
     diff(a.elements, b.elements);
@@ -107,13 +100,12 @@ namespace
   // Compare out.txt
   void diff_sdpb_out_txt(const boost::filesystem::path &a_out_txt,
                          const boost::filesystem::path &b_out_txt,
-                         unsigned int binary_precision,
                          const std::vector<std::string> &keys_to_compare)
   {
     CAPTURE(a_out_txt);
     CAPTURE(b_out_txt);
-    Parse_Sdpb_Out_Txt a(a_out_txt, binary_precision);
-    Parse_Sdpb_Out_Txt b(a_out_txt, binary_precision);
+    Parse_Sdpb_Out_Txt a(a_out_txt);
+    Parse_Sdpb_Out_Txt b(a_out_txt);
 
     auto keys = keys_to_compare;
     // By default, test each key except for "Solver runtime"
@@ -158,6 +150,7 @@ namespace Test_Util::REQUIRE_Equal
     CAPTURE(b_out_dir);
     REQUIRE(is_directory(a_out_dir));
     REQUIRE(is_directory(b_out_dir));
+    Float_Binary_Precision prec(binary_precision);
 
     std::vector<std::string> my_filenames = filenames;
     if(my_filenames.empty())
@@ -185,9 +178,9 @@ namespace Test_Util::REQUIRE_Equal
         auto b = b_out_dir / name;
 
         if(name == "out.txt")
-          diff_sdpb_out_txt(a, b, binary_precision, out_txt_keys);
+          diff_sdpb_out_txt(a, b, out_txt_keys);
         else
-          diff_matrix_txt(a, b, binary_precision);
+          diff_matrix_txt(a, b);
       }
   }
 }

--- a/test/src/integration_tests/util/diff_sdpb_out.cxx
+++ b/test/src/integration_tests/util/diff_sdpb_out.cxx
@@ -141,7 +141,8 @@ namespace Test_Util::REQUIRE_Equal
 {
   void diff_sdpb_output_dir(const boost::filesystem::path &a_out_dir,
                             const boost::filesystem::path &b_out_dir,
-                            unsigned int binary_precision,
+                            unsigned int input_precision,
+                            unsigned int diff_precision,
                             const std::vector<std::string> &filenames,
                             const std::vector<std::string> &out_txt_keys)
   {
@@ -150,7 +151,7 @@ namespace Test_Util::REQUIRE_Equal
     CAPTURE(b_out_dir);
     REQUIRE(is_directory(a_out_dir));
     REQUIRE(is_directory(b_out_dir));
-    Float_Binary_Precision prec(binary_precision);
+    Float_Binary_Precision prec(input_precision, diff_precision);
 
     std::vector<std::string> my_filenames = filenames;
     if(my_filenames.empty())

--- a/test/src/integration_tests/util/diff_spectrum.cxx
+++ b/test/src/integration_tests/util/diff_spectrum.cxx
@@ -60,13 +60,13 @@ namespace
 
   void diff(const Zero &a, const Zero &b)
   {
-    diff(a.zero, b.zero);
-    diff(a.lambda, b.lambda);
+    DIFF(a.zero, b.zero);
+    DIFF(a.lambda, b.lambda);
   }
   void diff(const Zeros &a, const Zeros &b)
   {
-    diff(a.error, b.error);
-    diff(a.zeros, b.zeros);
+    DIFF(a.error, b.error);
+    DIFF(a.zeros, b.zeros);
   }
 }
 
@@ -83,6 +83,6 @@ namespace Test_Util::REQUIRE_Equal
     Float_Binary_Precision prec(input_precision, diff_precision);
     Parse_Spectrum_Json a(a_json);
     Parse_Spectrum_Json b(b_json);
-    diff(a.zeros_array, b.zeros_array);
+    DIFF(a.zeros_array, b.zeros_array);
   }
 }

--- a/test/src/integration_tests/util/diff_spectrum.cxx
+++ b/test/src/integration_tests/util/diff_spectrum.cxx
@@ -31,12 +31,10 @@ namespace
     std::vector<Zeros> zeros_array;
 
     std::vector<std::pair<std::string, std::string>> options;
-    explicit Parse_Spectrum_Json(const boost::filesystem::path &path,
-                                 unsigned int binary_precision)
+    explicit Parse_Spectrum_Json(const boost::filesystem::path &path)
     {
       CAPTURE(path);
       REQUIRE(exists(path));
-      Float_Binary_Precision _(binary_precision);
       boost::filesystem::ifstream is(path);
       rapidjson::IStreamWrapper wrapper(is);
       rapidjson::Document document;
@@ -82,8 +80,9 @@ namespace Test_Util::REQUIRE_Equal
     INFO("diff spectrum output");
     CAPTURE(a_json);
     CAPTURE(b_json);
-    Parse_Spectrum_Json a(a_json, binary_precision);
-    Parse_Spectrum_Json b(b_json, binary_precision);
+    Float_Binary_Precision prec(binary_precision);
+    Parse_Spectrum_Json a(a_json);
+    Parse_Spectrum_Json b(b_json);
     diff(a.zeros_array, b.zeros_array);
   }
 }

--- a/test/src/integration_tests/util/diff_spectrum.cxx
+++ b/test/src/integration_tests/util/diff_spectrum.cxx
@@ -75,12 +75,12 @@ namespace Test_Util::REQUIRE_Equal
 {
   void diff_spectrum(const boost::filesystem::path &a_json,
                      const boost::filesystem::path &b_json,
-                     unsigned int binary_precision)
+                     unsigned int input_precision, unsigned int diff_precision)
   {
     INFO("diff spectrum output");
     CAPTURE(a_json);
     CAPTURE(b_json);
-    Float_Binary_Precision prec(binary_precision);
+    Float_Binary_Precision prec(input_precision, diff_precision);
     Parse_Spectrum_Json a(a_json);
     Parse_Spectrum_Json b(b_json);
     diff(a.zeros_array, b.zeros_array);

--- a/test/src/integration_tests/util/json.hxx
+++ b/test/src/integration_tests/util/json.hxx
@@ -26,10 +26,19 @@ namespace Test_Util::Json
   }
   inline Float_Matrix parse_Float_Matrix(const Json_Value &json_value)
   {
-    Float_Matrix result;
-    for(const auto &element : json_value.GetArray())
+    auto rows_array = json_value.GetArray();
+    int height = rows_array.Size();
+    int width = rows_array[0].GetArray().Size();
+    Float_Matrix result(height, width);
+
+    for(int row = 0; row < height; ++row)
       {
-        result.emplace_back(parse_Float_Vector(element));
+        auto cols_array = rows_array[row].GetArray();
+        for(int col = 0; col < width; ++col)
+          {
+            Float value = parse_Float(cols_array[col]);
+            result.Set(row, col, value);
+          }
       }
     return result;
   }


### PR DESCRIPTION
Some minor improvements:
- Print `stderr` to console if process fails.
- Use `El::BigFloat`, compare them up to a specified precision (necessary for end-to-end tests).
- `DIFF(a,b)` macro printing argument names
- Do not fail tests if we expect, e.g., exit code=1 but get 137 (real case on Yale cluster: MPI process exits with code 1, but srun returns 137).