### PR TITLE
Test and benchmark for block_data SDP serialization (JSON/binary)

### DIFF
--- a/Install.md
+++ b/Install.md
@@ -5,6 +5,7 @@ notes](docs/site_installs/Readme.md) for different HPC machines.
 
 * [Requirements](#requirements)
 * [Installation](#installation)
+* [Tests](#tests)
 * [Getting Help](#getting-help)
 
 # Requirements
@@ -119,33 +120,39 @@ manager such as [Homebrew](https://brew.sh).
     * `unit_tests`: Unit tests.
     * `integration_tests`: End-to-end tests for `sdpb` and other executables. The tests use data from `test/data/` folder.
 
-8. You can check the installation by running `unit_tests` and `integration_tests` (takes up to several minutes):
-8. You can check the installation by running `integration_tests` (takes up to several minutes):
+Running
+
+        ./build/sdpb --help
+
+should give you a usage message. HPC systems may require you to run
+all jobs through a batch system. You will need to consult the
+documentation for your individual system.
+
+# Tests<a name="tests" />
+
+You can check the installation by running `unit_tests` and `integration_tests` (takes up to several minutes):
 
         mpirun -n 2 ./build/unit_tests
         ./build/integration_tests
 
-   If some integration test case fails, you may check the test logs in `test/out/log/` folder and files generated during the test run in `test/out/` folder.
+If some integration test case fails, you may check the test logs in `test/out/log/` folder and files generated during
+the test run in `test/out/` folder.
 
-    By default, `integration_tests` uses `mpirun` command to run `sdpb` and other executables. You can also provide a custom command for your HPC, e.g.:
+By default, `integration_tests` uses `mpirun` command to run `sdpb` and other executables. You can also provide a custom
+command for your HPC, e.g.:
 
         ./build/integration_tests --mpirun="srun --mpi=pmi2" 
-    For more command-line options, see [Catch2 documentation](https://github.com/catchorg/Catch2/blob/devel/docs/command-line.md).
- 
-    You can also run both unit and integration tests via the script
 
-        ./test/run_all_tests.sh 
-    It also supports custom mpirun command, e.g. 
+For more command-line options,
+see [Catch2 documentation](https://github.com/catchorg/Catch2/blob/devel/docs/command-line.md).
+
+You can also run both unit and integration tests via the script
+
+        ./test/run_all_tests.sh
+
+It also supports custom mpirun command, e.g.
 
         ./test/run_all_tests.sh srun --mpi=pmi2
-
-Running
-   
-        ./build/sdpb --help
-
-should give you a usage message.  HPC systems may require you to run
-all jobs through a batch system.  You will need to consult the
-documentation for your individual system.
 
 # Getting Help<a name="getting-help" />
 If you are having problems with installation, you can [create an issue on GitHub](https://github.com/davidsd/sdpb/issues/new).
@@ -153,4 +160,6 @@ Be sure to include what system you are trying
 to install SDPB on, what you typed, and the **FULL** error message
 (even if you think it is too long).
 
-If installation was successful but some test case fails, please include also the corresponding logs, e.g. `test/out/log/sdpb/run.stdout.log` and `test/out/log/sdpb/run.stderr.log`.
+If installation was successful but some test case fails, please include also the console output and (in the case of
+integration tests) the corresponding logs, e.g. `test/out/log/sdpb/run.stdout.log`
+and `test/out/log/sdpb/run.stderr.log`.

--- a/test/src/integration_tests/util/diff.hxx
+++ b/test/src/integration_tests/util/diff.hxx
@@ -1,24 +1,16 @@
 #pragma once
 
-#include "Float.hxx"
+#include "test_util/diff.hxx"
 #include "Test_Case_Runner.hxx"
 
 #include <catch2/catch_amalgamated.hpp>
 #include <boost/filesystem.hpp>
-
-#define DIFF(a, b)                                                            \
-  {                                                                           \
-    INFO("DIFF(" << #a << ", " << #b << ")");                                 \
-    diff(a, b);                                                               \
-  }
 
 // Functions that REQUIRE equality of given files or folders.
 // NB: we call REQUIRE() inside these functions,
 // because otherwise useful CAPTURE() information will be lost
 namespace Test_Util::REQUIRE_Equal
 {
-  inline unsigned int diff_precision;
-
   // Compare SDPB output directories by content.
   // filenames: which files to compare (by default - all)
   // out_txt_keys: which keys compare in out.txt
@@ -45,58 +37,4 @@ namespace Test_Util::REQUIRE_Equal
   diff_spectrum(const boost::filesystem::path &a_json,
                 const boost::filesystem::path &b_json,
                 unsigned int input_precision, unsigned int diff_precision);
-
-  inline void diff(int a, int b) { REQUIRE(a == b); }
-  inline void diff(const Float &a, const Float &b)
-  {
-    if(a == b)
-      return;
-
-    CAPTURE(a);
-    CAPTURE(b);
-    CAPTURE(a - b);
-
-    CAPTURE(diff_precision);
-    REQUIRE(diff_precision > 0);
-
-    auto eps = Float(1) >>= diff_precision; // 2^{-precision}
-    CAPTURE(eps);
-    REQUIRE(Abs(a - b) < eps * (Abs(a) + Abs(b)));
-  }
-  inline void diff(const std::string &a, const std::string &b)
-  {
-    REQUIRE(a == b);
-  }
-  template <class T1, class T2>
-  inline void diff(const std::pair<T1, T2> &a, const std::pair<T1, T2> &b)
-  {
-    INFO("diff std::pair");
-    DIFF(a.first, b.first);
-    DIFF(a.second, b.second);
-  }
-  template <class T>
-  inline void diff(const std::vector<T> &a, const std::vector<T> &b)
-  {
-    INFO("diff std::vector");
-    REQUIRE(a.size() == b.size());
-    for(size_t i = 0; i < a.size(); ++i)
-      {
-        CAPTURE(i);
-        DIFF(a[i], b[i]);
-      }
-  }
-  template <class T>
-  inline void diff(const El::Matrix<T> &a, const El::Matrix<T> &b)
-  {
-    INFO("diff El::Matrix");
-    REQUIRE(a.Height() == b.Height());
-    REQUIRE(a.Width() == b.Width());
-    for(int row = 0; row < a.Height(); ++row)
-      for(int col = 0; col < a.Width(); ++col)
-        {
-          CAPTURE(row);
-          CAPTURE(col);
-          DIFF(a.Get(row, col), b.Get(row, col));
-        }
-  }
 }

--- a/test/src/test_util/diff.hxx
+++ b/test/src/test_util/diff.hxx
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <catch2/catch_amalgamated.hpp>
+#include <El.hpp>
+#include <boost/filesystem.hpp>
+
+#define DIFF(a, b)                                                            \
+  {                                                                           \
+    INFO("DIFF(" << #a << ", " << #b << ")");                                 \
+    diff(a, b);                                                               \
+  }
+
+// Functions that REQUIRE equality of given files or folders.
+// NB: we call REQUIRE() inside these functions,
+// because otherwise useful CAPTURE() information will be lost
+namespace Test_Util::REQUIRE_Equal
+{
+  inline int diff_precision;
+
+  inline void diff(int a, int b) { REQUIRE(a == b); }
+  inline void diff(const El::BigFloat &a, const El::BigFloat &b)
+  {
+    if(a == b)
+      return;
+
+    CAPTURE(a);
+    CAPTURE(b);
+    CAPTURE(a - b);
+
+    CAPTURE(diff_precision);
+    if(diff_precision == 0)
+      FAIL("diff_precision not initialized. "
+           "Set diff_precision=-1 to enforce exact comparison, "
+           "or to some positive number of bits.");
+
+    if(diff_precision < 0)
+      {
+        REQUIRE(a == b);
+        return;
+      }
+
+    REQUIRE(diff_precision > 0);
+
+    auto eps = El::BigFloat(1) >>= diff_precision; // 2^{-precision}
+    CAPTURE(eps);
+    REQUIRE(Abs(a - b) < eps * (Abs(a) + Abs(b)));
+  }
+  inline void diff(const std::string &a, const std::string &b)
+  {
+    REQUIRE(a == b);
+  }
+  template <class T1, class T2>
+  inline void diff(const std::pair<T1, T2> &a, const std::pair<T1, T2> &b)
+  {
+    INFO("diff std::pair");
+    DIFF(a.first, b.first);
+    DIFF(a.second, b.second);
+  }
+  template <class T>
+  inline void diff(const std::vector<T> &a, const std::vector<T> &b)
+  {
+    INFO("diff std::vector");
+    REQUIRE(a.size() == b.size());
+    for(size_t i = 0; i < a.size(); ++i)
+      {
+        CAPTURE(i);
+        DIFF(a[i], b[i]);
+      }
+  }
+  template <class T>
+  inline void diff(const El::Matrix<T> &a, const El::Matrix<T> &b)
+  {
+    INFO("diff El::Matrix");
+    REQUIRE(a.Height() == b.Height());
+    REQUIRE(a.Width() == b.Width());
+    for(int row = 0; row < a.Height(); ++row)
+      for(int col = 0; col < a.Width(); ++col)
+        {
+          CAPTURE(row);
+          CAPTURE(col);
+          DIFF(a.Get(row, col), b.Get(row, col));
+        }
+  }
+}

--- a/test/src/unit_tests/cases/block_data_serialization.test.cxx
+++ b/test/src/unit_tests/cases/block_data_serialization.test.cxx
@@ -1,0 +1,117 @@
+#include <catch2/catch_amalgamated.hpp>
+#include <El.hpp>
+#include <sstream>
+
+#include "unit_tests/util/util.hxx"
+#include "sdp_convert/Dual_Constraint_Group.hxx"
+
+using Test_Util::random_bigfloat;
+using Test_Util::random_matrix;
+using Test_Util::random_vector;
+using Test_Util::REQUIRE_Equal::diff;
+
+void write_block_data(std::ostream &os, const Dual_Constraint_Group &group,
+                      Block_File_Format format);
+void parse_block_data(std::istream &block_stream, Block_File_Format format,
+                      El::Matrix<El::BigFloat> &constraint_matrix,
+                      std::vector<El::BigFloat> &constraint_constants,
+                      El::Matrix<El::BigFloat> &bilinear_bases_even,
+                      El::Matrix<El::BigFloat> &bilinear_bases_odd);
+
+namespace
+{
+  Dual_Constraint_Group
+  serialize_deserialize(const Dual_Constraint_Group &group,
+                        Block_File_Format format)
+  {
+    std::stringstream ss;
+    write_block_data(ss, group, format);
+
+    Dual_Constraint_Group result;
+    parse_block_data(ss, format, result.constraint_matrix,
+                     result.constraint_constants, result.bilinear_bases[0],
+                     result.bilinear_bases[1]);
+    result.dim = group.dim;
+    result.num_points = group.num_points;
+    return result;
+  }
+
+  using Test_Util::REQUIRE_Equal::diff;
+  void diff(const Dual_Constraint_Group &a, const Dual_Constraint_Group &b)
+  {
+    DIFF(a.dim, b.dim);
+    DIFF(a.num_points, b.num_points);
+    DIFF(a.constraint_matrix, b.constraint_matrix);
+    DIFF(a.constraint_constants, b.constraint_constants);
+    DIFF(a.bilinear_bases[0], b.bilinear_bases[0]);
+    DIFF(a.bilinear_bases[1], b.bilinear_bases[1]);
+  }
+
+  // Dual_Constraint_Group with the same sizes as block_0 in integration test
+  // end-to-end_tests/SingletScalar_cT_test_nmax6/primal_dual_optimal
+  Dual_Constraint_Group random_group_from_singlet_scalar_block_0()
+  {
+    Dual_Constraint_Group group;
+    group.dim = 1;
+    group.num_points = 24;
+    int P = 24;
+    int N = 20;
+    group.constraint_matrix = random_matrix(P, N);
+    group.constraint_constants = random_vector(P);
+    group.bilinear_bases[0] = random_matrix(12, 24);
+    group.bilinear_bases[1] = random_matrix(12, 24);
+    return group;
+  }
+}
+
+TEST_CASE("block_data serialization")
+{
+  // this test is purely single-process, thus testing at rank=0 is sufficient
+  if(El::mpi::Rank() != 0)
+    return;
+
+  El::InitializeRandom(true);
+  Dual_Constraint_Group group = random_group_from_singlet_scalar_block_0();
+
+  Block_File_Format format = GENERATE(bin, json);
+  DYNAMIC_SECTION((format == bin ? ".bin" : ".json"))
+  {
+    auto other = serialize_deserialize(group, format);
+    DIFF(group, other);
+  }
+}
+
+TEST_CASE("benchmark block_data write+parse", "[!benchmark]")
+{
+  // this test is purely single-process, thus testing at rank=0 is sufficient
+  if(El::mpi::Rank() != 0)
+    return;
+
+  El::InitializeRandom(true);
+  Dual_Constraint_Group group = random_group_from_singlet_scalar_block_0();
+
+  // Change constraint_matrix size to see how bin/json scales
+  int B_width = GENERATE(20, 100, 1000, 10000);
+  group.constraint_matrix
+    = random_matrix(group.constraint_matrix.Height(), B_width);
+
+  int total_count = 0;
+  total_count += group.constraint_constants.size();
+  for(const auto &matrix : {group.constraint_matrix, group.bilinear_bases[0],
+                            group.bilinear_bases[1]})
+    {
+      total_count += matrix.Height() * matrix.Width();
+    }
+
+  DYNAMIC_SECTION(total_count << " BigFloats")
+  {
+    // We could put this benchmarks into different DYNAMIC_SECTION's,
+    // using Block_File_Format format = GENERATE(bin, json);
+    // But it would make output less concise
+    BENCHMARK("write+parse bin") { return serialize_deserialize(group, bin); };
+    BENCHMARK("write+parse JSON")
+    {
+      return serialize_deserialize(group, json);
+    };
+  }
+}

--- a/test/src/unit_tests/cases/boost_serialization.test.cxx
+++ b/test/src/unit_tests/cases/boost_serialization.test.cxx
@@ -2,6 +2,11 @@
 #include <boost_serialization.hxx>
 #include <El.hpp>
 #include <sstream>
+#include "unit_tests/util/util.hxx"
+
+using Test_Util::random_bigfloat;
+using Test_Util::random_matrix;
+using Test_Util::REQUIRE_Equal::diff;
 
 namespace
 {
@@ -16,34 +21,6 @@ namespace
     in >> deserialized_value;
 
     return deserialized_value;
-  }
-
-  El::BigFloat random_bigfloat()
-  {
-    return El::SampleUniform<El::BigFloat>(-3.14, 3.14);
-  }
-  El::Matrix<El::BigFloat> random_matrix(int height, int width)
-  {
-    El::Matrix<El::BigFloat> matrix(height, width);
-    for(int i = 0; i < height; ++i)
-      for(int k = 0; k < width; ++k)
-        {
-          matrix.Set(i, k, random_bigfloat());
-        }
-
-    return matrix;
-  }
-
-  void diff(El::Matrix<El::BigFloat> a, El::Matrix<El::BigFloat> b)
-  {
-    // Compare dimensions
-    REQUIRE(b.Height() == a.Height());
-    REQUIRE(a.Width() == b.Width());
-    REQUIRE(a.LDim() == b.LDim());
-    // Elementwise comparison
-    for(int i = 0; i < a.Height(); ++i)
-      for(int k = 0; k < a.Width(); ++k)
-        REQUIRE(a.Get(i, k) == b.Get(i, k));
   }
 }
 
@@ -71,6 +48,6 @@ TEST_CASE("Boost serialization")
     El::Matrix<El::BigFloat> other = serialize_deserialize(matrix);
     // Sanity check: deserialized_matrix is not the same as matrix
     REQUIRE(matrix.LockedBuffer() != other.LockedBuffer());
-    diff(matrix, other);
+    DIFF(matrix, other);
   }
 }

--- a/test/src/unit_tests/main.cxx
+++ b/test/src/unit_tests/main.cxx
@@ -2,6 +2,7 @@
 #include <El.hpp>
 #include <iostream>
 #include <sstream>
+#include "test_util/diff.hxx"
 
 #ifndef CATCH_AMALGAMATED_CUSTOM_MAIN
 #error "To override main, pass '-D CATCH_AMALGAMATED_CUSTOM_MAIN' to compiler"
@@ -11,6 +12,7 @@ int main(int argc, char *argv[])
 {
   El::Environment env(argc, argv);
   El::gmp::SetPrecision(128);
+  Test_Util::REQUIRE_Equal::diff_precision = El::gmp::Precision();
 
   int rank = El::mpi::Rank();
 

--- a/test/src/unit_tests/main.cxx
+++ b/test/src/unit_tests/main.cxx
@@ -11,7 +11,7 @@
 int main(int argc, char *argv[])
 {
   El::Environment env(argc, argv);
-  El::gmp::SetPrecision(128);
+  El::gmp::SetPrecision(768);
   Test_Util::REQUIRE_Equal::diff_precision = El::gmp::Precision();
 
   int rank = El::mpi::Rank();

--- a/test/src/unit_tests/util/util.hxx
+++ b/test/src/unit_tests/util/util.hxx
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "test_util/diff.hxx"
+
+#include <vector>
+#include <El.hpp>
+
+namespace Test_Util
+{
+  inline El::BigFloat random_bigfloat()
+  {
+    return El::SampleUniform<El::BigFloat>(-1.0, 1.0);
+  }
+
+  inline std::vector<El::BigFloat>
+  random_vector(size_t size, const std::function<El::BigFloat()> &make_float
+                             = random_bigfloat)
+  {
+    std::vector<El::BigFloat> vec(size);
+    for(auto &item : vec)
+      {
+        item = make_float();
+      }
+    return vec;
+  }
+
+  inline El::Matrix<El::BigFloat>
+  random_matrix(int height, int width,
+                const std::function<El::BigFloat()> &make_float
+                = random_bigfloat)
+  {
+    El::Matrix<El::BigFloat> matrix(height, width);
+    for(int i = 0; i < height; ++i)
+      for(int k = 0; k < width; ++k)
+        {
+          matrix.Set(i, k, make_float());
+        }
+
+    return matrix;
+  }
+}

--- a/wscript
+++ b/wscript
@@ -311,9 +311,10 @@ def build(bld):
                 )
     bld.program(source=['external/catch2/catch_amalgamated.cpp',
                         'test/src/unit_tests/main.cxx',
+                        'test/src/unit_tests/cases/block_data_serialization.test.cxx',
                         'test/src/unit_tests/cases/boost_serialization.test.cxx'],
                 target='unit_tests',
                 cxxflags=default_flags + ['-D CATCH_AMALGAMATED_CUSTOM_MAIN'],
-                use=use_packages,
+                use=use_packages + ['sdp_convert', 'sdp_solve'],
                 includes=default_includes + ['test/src']
                 )

--- a/wscript
+++ b/wscript
@@ -315,5 +315,5 @@ def build(bld):
                 target='unit_tests',
                 cxxflags=default_flags + ['-D CATCH_AMALGAMATED_CUSTOM_MAIN'],
                 use=use_packages,
-                includes=default_includes
+                includes=default_includes + ['test/src']
                 )


### PR DESCRIPTION
- Added a simple test and benchmark for `block_data` serialization to `unit tests`.
- Some refactoring in tests - extracted common `DIFF` functions used in both unit and integration tests.

`block_data_serialization.test` writes block_data (constraint matrix `B`, constraint vector `c` and blilinear bases) to stringstream and then reads them back.
On my laptop, the benchmarking results are kind of unstable, but generally show **~20x-30x** speedup for binary format compared to JSON (see #79).

Note that in real applications the expected bottlneck is disk IO, so one can expect up to **~2.4x** speedup.
I observed such numbers for writing sdp in small end-to-end tests, but they should be taken with a grain of salt. I haven't benchmarked any big problem.

Note that, by default, Catch2 framework [does not run](https://github.com/catchorg/Catch2/blob/devel/docs/test-cases-and-sections.md#special-tags) test cases marked by `[!benchmark]`
To run benchmark, run unit_tests as follows:
```
./build/unit_tests [!benchmark]
```
Catch2 by default uses 100 samples (i.e. runs each benchmark 100 times) and prints detailed statistics.
For a simple and fast output, you can run, e.g.,
```
./build/unit_tests [!benchmark] --benchmark-samples 10 --benchmark-no-analysis 
```
More information on Catch2 benchmarks and command-line options:
https://github.com/catchorg/Catch2/blob/devel/docs/benchmarks.md
https://github.com/catchorg/Catch2/blob/devel/docs/command-line.md

P.S.