### PR TITLE
Binary sdp: enable by default and add option to pvm2sdp

### DIFF
--- a/src/pvm2sdp/main.cxx
+++ b/src/pvm2sdp/main.cxx
@@ -2,7 +2,9 @@
 
 namespace fs = std::filesystem;
 
-void parse_command_line(int argc, char **argv, int &precision,
+// TODO use boost::program_options
+void parse_command_line(int argc, char **argv,
+                        Block_File_Format &output_format, int &precision,
                         std::vector<fs::path> &input_files,
                         fs::path &output_dir);
 
@@ -18,15 +20,15 @@ int main(int argc, char **argv)
   const int rank(El::mpi::Rank());
   try
     {
+      Block_File_Format output_format = bin;
       int precision;
       std::vector<fs::path> input_files;
       fs::path output_path;
 
-      // TODO read the following from command line:
-      Block_File_Format output_format = json;
       bool debug = false;
 
-      parse_command_line(argc, argv, precision, input_files, output_path);
+      parse_command_line(argc, argv, output_format, precision, input_files,
+                         output_path);
       El::gmp::SetPrecision(precision);
 
       El::BigFloat objective_const;

--- a/src/pvm2sdp/parse_command_line.cxx
+++ b/src/pvm2sdp/parse_command_line.cxx
@@ -2,15 +2,21 @@
 #include <vector>
 #include <iostream>
 #include <stdexcept>
+#include "../sdp_convert/Block_File_Format.hxx"
 
 using namespace std::literals;
 namespace fs = std::filesystem;
 
-void parse_command_line(int argc, char **argv, int &precision,
+void parse_command_line(int argc, char **argv,
+                        Block_File_Format &output_format, int &precision,
                         std::vector<fs::path> &input_files,
                         fs::path &output_dir)
 {
-  std::string usage("pvm2sdp [PRECISION] [INPUT]... [OUTPUT_DIR]\n");
+  std::string usage("pvm2sdp [FORMAT] PRECISION INPUT... OUTPUT\n"
+                    "FORMAT (optional): output format, bin (default) or json\n"
+                    "PRECISION: binary precision\n"
+                    "INPUT: input .xml or .nsv files\n"
+                    "OUTPUT: output sdp.zip file");
   for(int arg = 1; arg < argc; ++arg)
     {
       if((argv[arg] == "-h"s) || argv[arg] == "--help"s)
@@ -20,13 +26,21 @@ void parse_command_line(int argc, char **argv, int &precision,
         }
     }
 
-  if(argc < 4)
+  size_t curr_arg_pos = 1;
+  std::string first_arg = argv[curr_arg_pos];
+  if(first_arg == "bin" || first_arg == "json")
+    {
+      output_format = first_arg == "bin" ? bin : json;
+      curr_arg_pos = 2;
+    }
+
+  if(argc - curr_arg_pos < 3)
     {
       std::cerr << "Wrong number of arguments\n" << usage;
       exit(1);
     }
 
-  std::string precision_string(argv[1]);
+  std::string precision_string(argv[curr_arg_pos]);
   size_t pos;
   try
     {
@@ -42,8 +56,9 @@ void parse_command_line(int argc, char **argv, int &precision,
       throw std::runtime_error("Precision has trailing characters: '"
                                + precision_string.substr(pos) + "'");
     }
+  curr_arg_pos++;
 
-  input_files.insert(input_files.end(), argv + 2, argv + argc - 1);
+  input_files.insert(input_files.end(), argv + curr_arg_pos, argv + argc - 1);
   for(auto &file : input_files)
     {
       if(!fs::exists(file))

--- a/src/sdp2input/main.cxx
+++ b/src/sdp2input/main.cxx
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
       options.add_options()(
         "outputFormat,f",
         po::value<Block_File_Format>(&output_format)
-          ->default_value(Block_File_Format::json),
+          ->default_value(Block_File_Format::bin),
         "Output format for SDP blocks. Could be either 'bin' or 'json'");
       options.add_options()("debug",
                             po::value<bool>(&debug)->default_value(false),


### PR DESCRIPTION
- #127 
- #123 
- Add tests

New `pvm2sdp` usage:
```
pvm2sdp [FORMAT] PRECISION INPUT... OUTPUT
```
`FORMAT` is `bin` or `json`; if not specified, `bin` is used by default.