### PR TITLE
Fix #99 Push/pop Timer name prefixes 

### DIFF
--- a/src/Timer.hxx
+++ b/src/Timer.hxx
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <chrono>
 #include <iostream>
 
@@ -7,25 +8,42 @@ struct Timer
 {
   std::chrono::time_point<std::chrono::high_resolution_clock> start_time,
     stop_time;
-  Timer() : start_time(std::chrono::high_resolution_clock::now()) {}
-  auto stop() { stop_time = std::chrono::high_resolution_clock::now(); }
-
-  int64_t elapsed_milliseconds() const
+  Timer() : start_time(now()) {}
+  auto stop()
   {
-    return std::chrono::duration_cast<std::chrono::milliseconds>(stop_time
-                                                                 - start_time)
-      .count();
+    assert(is_running());
+    stop_time = now();
+    running = false;
   }
-  int64_t elapsed_seconds() const
+
+  [[nodiscard]] int64_t elapsed_milliseconds() const
   {
-    return std::chrono::duration_cast<std::chrono::seconds>(stop_time
-                                                            - start_time)
-      .count();
+    return elapsed<std::chrono::milliseconds>();
+  }
+  [[nodiscard]] int64_t elapsed_seconds() const
+  {
+    return elapsed<std::chrono::seconds>();
+  }
+
+private:
+  bool running = true;
+
+  [[nodiscard]] bool is_running() const { return running; }
+
+  static std::chrono::time_point<std::chrono::high_resolution_clock> now()
+  {
+    return std::chrono::high_resolution_clock::now();
+  }
+
+  template <class Duration> [[nodiscard]] int64_t elapsed() const
+  {
+    auto end_time = is_running() ? now() : stop_time;
+    return std::chrono::duration_cast<Duration>(end_time - start_time).count();
   }
 };
 
 inline std::ostream &operator<<(std::ostream &os, const Timer &timer)
 {
-  os << (timer.elapsed_milliseconds()/1000.0);
+  os << (timer.elapsed_milliseconds() / 1000.0);
   return os;
 }

--- a/src/Timer.hxx
+++ b/src/Timer.hxx
@@ -25,10 +25,10 @@ struct Timer
     return elapsed<std::chrono::seconds>();
   }
 
+  [[nodiscard]] bool is_running() const { return running; }
+
 private:
   bool running = true;
-
-  [[nodiscard]] bool is_running() const { return running; }
 
   static std::chrono::time_point<std::chrono::high_resolution_clock> now()
   {

--- a/src/Timers.hxx
+++ b/src/Timers.hxx
@@ -11,6 +11,7 @@
 
 #include <El.hpp>
 
+#include <cassert>
 #include <fstream>
 #include <string>
 #include <list>
@@ -179,8 +180,26 @@ struct Scoped_Timer : boost::noncopyable
   Scoped_Timer(Timers &timers, const std::string &name)
       : my_timer(timers.add_and_start(name))
   {}
-  virtual ~Scoped_Timer() { my_timer.stop(); }
+  virtual ~Scoped_Timer()
+  {
+    if(is_running())
+      stop();
+  }
+
+  [[nodiscard]] std::chrono::time_point<std::chrono::high_resolution_clock>
+  start_time() const
+  {
+    return my_timer.start_time;
+  }
+
+  void stop()
+  {
+    // Don't stop timer twice!
+    assert(is_running());
+    my_timer.stop();
+  }
 
 private:
   Timer &my_timer;
+  [[nodiscard]] bool is_running() const { return my_timer.is_running(); }
 };

--- a/src/sdp2input/main.cxx
+++ b/src/sdp2input/main.cxx
@@ -106,6 +106,7 @@ int main(int argc, char **argv)
       std::vector<El::BigFloat> objectives, normalization;
       std::vector<Positive_Matrix_With_Prefactor> matrices;
       Timers timers(debug);
+      Scoped_Timer timer(timers, "sdp2input");
       {
         Scoped_Timer read_input_timer(timers, "read_input");
         read_input(input_file, objectives, normalization, matrices);

--- a/src/sdp2input/main.cxx
+++ b/src/sdp2input/main.cxx
@@ -106,10 +106,10 @@ int main(int argc, char **argv)
       std::vector<El::BigFloat> objectives, normalization;
       std::vector<Positive_Matrix_With_Prefactor> matrices;
       Timers timers(debug);
-      auto &read_input_timer(timers.add_and_start("read_input"));
-      read_input(input_file, objectives, normalization, matrices);
-      read_input_timer.stop();
-      auto &write_output_timer(timers.add_and_start("write_output"));
+      {
+        Scoped_Timer read_input_timer(timers, "read_input");
+        read_input(input_file, objectives, normalization, matrices);
+      }
       std::vector<std::string> command_arguments;
       for(int arg(0); arg != argc; ++arg)
         {
@@ -117,7 +117,6 @@ int main(int argc, char **argv)
         }
       write_output(output_path, output_format, command_arguments, objectives,
                    normalization, matrices, timers, debug);
-      write_output_timer.stop();
       if(debug)
         {
           timers.write_profile(output_path.string() + ".profiling/profiling."

--- a/src/sdp2input/write_output/write_output.cxx
+++ b/src/sdp2input/write_output/write_output.cxx
@@ -18,7 +18,8 @@ void write_output(const fs::path &output_path, Block_File_Format output_format,
                   const std::vector<Positive_Matrix_With_Prefactor> &matrices,
                   Timers &timers, bool debug)
 {
-  auto &objectives_timer(timers.add_and_start("write_output.objectives"));
+  Scoped_Timer write_output_timer(timers, "write_output");
+  Scoped_Timer objectives_timer(timers, "write_output.objectives");
 
   const size_t max_index(max_normalization_index(normalization));
 
@@ -37,15 +38,15 @@ void write_output(const fs::path &output_path, Block_File_Format output_format,
 
   objectives_timer.stop();
 
-  auto &matrices_timer(timers.add_and_start("write_output.matrices"));
+  Scoped_Timer matrices_timer(timers, "write_output.matrices");
   std::vector<Dual_Constraint_Group> dual_constraint_groups;
   int rank(El::mpi::Rank(El::mpi::COMM_WORLD)),
     num_procs(El::mpi::Size(El::mpi::COMM_WORLD));
   std::vector<size_t> indices;
   for(size_t index = rank; index < matrices.size(); index += num_procs)
     {
-      auto &scalings_timer(timers.add_and_start(
-        "write_output.matrices.scalings_" + std::to_string(index)));
+      Scoped_Timer scalings_timer(timers, "write_output.matrices.scalings_"
+                                            + std::to_string(index));
       const size_t max_degree([&]() {
         int64_t result(0);
         for(auto &pvv : matrices[index].polynomials)
@@ -64,8 +65,9 @@ void write_output(const fs::path &output_path, Block_File_Format output_format,
       pvm.rows = matrices[index].polynomials.size();
       pvm.cols = matrices[index].polynomials.front().size();
 
-      auto &bilinear_basis_timer(timers.add_and_start(
-        "write_output.matrices.bilinear_basis_" + std::to_string(index)));
+      Scoped_Timer bilinear_basis_timer(timers,
+                                        "write_output.matrices.bilinear_basis_"
+                                          + std::to_string(index));
 
       pvm.bilinear_basis
         = bilinear_basis(matrices[index].damped_rational, max_degree / 2);
@@ -83,8 +85,8 @@ void write_output(const fs::path &output_path, Block_File_Format output_format,
           pvm.sample_scalings.emplace_back(to_string(scaling));
         }
 
-      auto &pvm_timer(timers.add_and_start("write_output.matrices.pvm_"
-                                           + std::to_string(index)));
+      Scoped_Timer pvm_timer(timers, "write_output.matrices.pvm_"
+                                       + std::to_string(index));
       pvm.elements.reserve(pvm.rows * pvm.cols);
       for(auto &pvv : matrices[index].polynomials)
         for(auto &pv : pvv)
@@ -130,16 +132,16 @@ void write_output(const fs::path &output_path, Block_File_Format output_format,
               }
           }
       pvm_timer.stop();
-      auto &dual_constraint_timer(timers.add_and_start(
-        "write_output.matrices.dual_constraint_" + std::to_string(index)));
+      Scoped_Timer dual_constraint_timer(
+        timers,
+        "write_output.matrices.dual_constraint_" + std::to_string(index));
       dual_constraint_groups.emplace_back(index, pvm);
       dual_constraint_timer.stop();
     }
   matrices_timer.stop();
 
-  auto &write_timer(timers.add_and_start("write_output.write"));
+  Scoped_Timer write_timer(timers, "write_output.write");
   write_sdpb_input_files(output_path, output_format, rank, matrices.size(),
                          command_arguments, objective_const, dual_objective_b,
                          dual_constraint_groups, debug);
-  write_timer.stop();
 }

--- a/src/sdp_solve/SDP_Solver/run/compute_bilinear_pairings/compute_bilinear_pairings.cxx
+++ b/src/sdp_solve/SDP_Solver/run/compute_bilinear_pairings/compute_bilinear_pairings.cxx
@@ -24,7 +24,7 @@ void compute_bilinear_pairings(
              2> &A_Y,
   Timers &timers)
 {
-  Scoped_Timer congruence_timer(timers, "run.bilinear_pairings");
+  Scoped_Timer congruence_timer(timers, "bilinear_pairings");
   compute_A_X_inv(block_info, X_cholesky, bases_blocks, A_X_inv);
 
   compute_A_Y(block_info, Y, bases_blocks, A_Y);

--- a/src/sdp_solve/SDP_Solver/run/compute_dual_residues_and_error.cxx
+++ b/src/sdp_solve/SDP_Solver/run/compute_dual_residues_and_error.cxx
@@ -11,7 +11,7 @@ void compute_dual_residues_and_error(
     &A_Y,
   Block_Vector &dual_residues, El::BigFloat &dual_error, Timers &timers)
 {
-  Scoped_Timer dual_residues_timer(timers, "run.computeDualResidues");
+  Scoped_Timer dual_residues_timer(timers, "computeDualResidues");
 
   auto dual_residues_block(dual_residues.blocks.begin());
   auto primal_objective_c_block(sdp.primal_objective_c.blocks.begin());

--- a/src/sdp_solve/SDP_Solver/run/compute_objectives/compute_objectives.cxx
+++ b/src/sdp_solve/SDP_Solver/run/compute_objectives/compute_objectives.cxx
@@ -8,7 +8,7 @@ void compute_objectives(const SDP &sdp, const Block_Vector &x,
                         El::BigFloat &dual_objective,
                         El::BigFloat &duality_gap, Timers &timers)
 {
-  auto &objectives_timer(timers.add_and_start("run.objectives"));
+  Scoped_Timer objectives_timer(timers, "run.objectives");
   primal_objective = sdp.objective_const + dot(sdp.primal_objective_c, x);
   // dual_objective_b is duplicated amongst the processors.  y is
   // duplicated amongst the blocks, but it is possible for some
@@ -26,6 +26,4 @@ void compute_objectives(const SDP &sdp, const Block_Vector &x,
   duality_gap
     = Abs(primal_objective - dual_objective)
       / Max(Abs(primal_objective) + Abs(dual_objective), El::BigFloat(1));
-
-  objectives_timer.stop();
 }

--- a/src/sdp_solve/SDP_Solver/run/compute_objectives/compute_objectives.cxx
+++ b/src/sdp_solve/SDP_Solver/run/compute_objectives/compute_objectives.cxx
@@ -8,7 +8,7 @@ void compute_objectives(const SDP &sdp, const Block_Vector &x,
                         El::BigFloat &dual_objective,
                         El::BigFloat &duality_gap, Timers &timers)
 {
-  Scoped_Timer objectives_timer(timers, "run.objectives");
+  Scoped_Timer objectives_timer(timers, "objectives");
   primal_objective = sdp.objective_const + dot(sdp.primal_objective_c, x);
   // dual_objective_b is duplicated amongst the processors.  y is
   // duplicated amongst the blocks, but it is possible for some

--- a/src/sdp_solve/SDP_Solver/run/compute_primal_residues_and_error_P_Ax_X.cxx
+++ b/src/sdp_solve/SDP_Solver/run/compute_primal_residues_and_error_P_Ax_X.cxx
@@ -7,7 +7,7 @@ void compute_primal_residues_and_error_P_Ax_X(
   const Block_Diagonal_Matrix &X, Block_Diagonal_Matrix &primal_residues,
   El::BigFloat &primal_error, Timers &timers)
 {
-  Scoped_Timer primal_residues_timer(timers, "run.computePrimalResidues");
+  Scoped_Timer primal_residues_timer(timers, "computePrimalResidues");
   constraint_matrix_weighted_sum(block_info, sdp, x, primal_residues);
   primal_residues -= X;
   primal_error = primal_residues.max_abs();

--- a/src/sdp_solve/SDP_Solver/run/run.cxx
+++ b/src/sdp_solve/SDP_Solver/run/run.cxx
@@ -67,8 +67,8 @@ SDP_Solver::run(const Solver_Parameters &parameters,
 {
   SDP_Solver_Terminate_Reason terminate_reason(
     SDP_Solver_Terminate_Reason::MaxIterationsExceeded);
-  Scoped_Timer solver_timer(timers, "Solver runtime");
-  Scoped_Timer initialize_timer(timers, "run.initialize");
+  Scoped_Timer solver_timer(timers, "run");
+  Scoped_Timer initialize_timer(timers, "initialize");
 
   El::BigFloat primal_step_length(0), dual_step_length(0);
 
@@ -112,6 +112,8 @@ SDP_Solver::run(const Solver_Parameters &parameters,
   auto last_checkpoint_time(std::chrono::high_resolution_clock::now());
   for(size_t iteration = 1;; ++iteration)
     {
+      Scoped_Timer iteration_timer(timers,
+                                   "iter_" + std::to_string(iteration));
       if(verbosity >= Verbosity::debug && El::mpi::Rank() == 0)
         {
           El::Output("Start iteration ", iteration, " at ",
@@ -135,7 +137,7 @@ SDP_Solver::run(const Solver_Parameters &parameters,
 
       {
         Scoped_Timer cholesky_decomposition_timer(timers,
-                                                  "run.choleskyDecomposition");
+                                                  "choleskyDecomposition");
         cholesky_decomposition(X, X_cholesky);
         cholesky_decomposition(Y, Y_cholesky);
       }

--- a/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/compute_schur_complement.cxx
+++ b/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/compute_schur_complement.cxx
@@ -22,8 +22,7 @@ void compute_schur_complement(
     &A_Y,
   Block_Diagonal_Matrix &schur_complement, Timers &timers)
 {
-  Scoped_Timer schur_complement_timer(
-    timers, "run.step.initializeSchurComplementSolver.schur_complement");
+  Scoped_Timer schur_complement_timer(timers, "schur_complement");
 
   auto schur_complement_block(schur_complement.blocks.begin());
   size_t Q_index(0);

--- a/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/initialize_Q_group.cxx
+++ b/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/initialize_Q_group.cxx
@@ -32,8 +32,7 @@ void initialize_Q_group(const SDP &sdp, const Block_Info &block_info,
       ++block)
     {
       Scoped_Timer cholesky_timer(
-        timers, "run.step.initializeSchurComplementSolver.Q.cholesky_"
-                  + std::to_string(block_info.block_indices[block]));
+        timers, "cholesky_" + std::to_string(block_info.block_indices[block]));
       schur_complement_cholesky.blocks[block] = schur_complement.blocks[block];
 
       Cholesky(El::UpperOrLowerNS::LOWER,
@@ -42,8 +41,7 @@ void initialize_Q_group(const SDP &sdp, const Block_Info &block_info,
 
       // schur_off_diagonal = L^{-1} B
       Scoped_Timer solve_timer(
-        timers, "run.step.initializeSchurComplementSolver.Q.solve_"
-                  + std::to_string(block_info.block_indices[block]));
+        timers, "solve_" + std::to_string(block_info.block_indices[block]));
 
       schur_off_diagonal.blocks.push_back(sdp.free_var_matrix.blocks[block]);
       El::Trsm(El::LeftOrRightNS::LEFT, El::UpperOrLowerNS::LOWER,
@@ -55,8 +53,7 @@ void initialize_Q_group(const SDP &sdp, const Block_Info &block_info,
 
       // Q = (L^{-1} B)^T (L^{-1} B) = schur_off_diagonal^T schur_off_diagonal
       Scoped_Timer syrk_timer(
-        timers, "run.step.initializeSchurComplementSolver.Q.syrk_"
-                  + std::to_string(block_info.block_indices[block]));
+        timers, "syrk_" + std::to_string(block_info.block_indices[block]));
       El::DistMatrix<El::BigFloat> Q_group_view(
         El::View(Q_group, 0, 0, schur_off_diagonal.blocks[block].Width(),
                  schur_off_diagonal.blocks[block].Width()));

--- a/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/initialize_Q_group.cxx
+++ b/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/initialize_Q_group.cxx
@@ -31,9 +31,9 @@ void initialize_Q_group(const SDP &sdp, const Block_Info &block_info,
   for(size_t block = 0; block < schur_complement_cholesky.blocks.size();
       ++block)
     {
-      auto &cholesky_timer(timers.add_and_start(
-        "run.step.initializeSchurComplementSolver.Q.cholesky_"
-        + std::to_string(block_info.block_indices[block])));
+      Scoped_Timer cholesky_timer(
+        timers, "run.step.initializeSchurComplementSolver.Q.cholesky_"
+                  + std::to_string(block_info.block_indices[block]));
       schur_complement_cholesky.blocks[block] = schur_complement.blocks[block];
 
       Cholesky(El::UpperOrLowerNS::LOWER,
@@ -41,9 +41,9 @@ void initialize_Q_group(const SDP &sdp, const Block_Info &block_info,
       cholesky_timer.stop();
 
       // schur_off_diagonal = L^{-1} B
-      auto &solve_timer(timers.add_and_start(
-        "run.step.initializeSchurComplementSolver.Q.solve_"
-        + std::to_string(block_info.block_indices[block])));
+      Scoped_Timer solve_timer(
+        timers, "run.step.initializeSchurComplementSolver.Q.solve_"
+                  + std::to_string(block_info.block_indices[block]));
 
       schur_off_diagonal.blocks.push_back(sdp.free_var_matrix.blocks[block]);
       El::Trsm(El::LeftOrRightNS::LEFT, El::UpperOrLowerNS::LOWER,
@@ -54,15 +54,14 @@ void initialize_Q_group(const SDP &sdp, const Block_Info &block_info,
       solve_timer.stop();
 
       // Q = (L^{-1} B)^T (L^{-1} B) = schur_off_diagonal^T schur_off_diagonal
-      auto &syrk_timer(timers.add_and_start(
-        "run.step.initializeSchurComplementSolver.Q.syrk_"
-        + std::to_string(block_info.block_indices[block])));
+      Scoped_Timer syrk_timer(
+        timers, "run.step.initializeSchurComplementSolver.Q.syrk_"
+                  + std::to_string(block_info.block_indices[block]));
       El::DistMatrix<El::BigFloat> Q_group_view(
         El::View(Q_group, 0, 0, schur_off_diagonal.blocks[block].Width(),
                  schur_off_diagonal.blocks[block].Width()));
       El::Syrk(El::UpperOrLowerNS::UPPER, El::OrientationNS::TRANSPOSE,
                El::BigFloat(1), schur_off_diagonal.blocks[block],
                El::BigFloat(1), Q_group_view);
-      syrk_timer.stop();
     }
 }

--- a/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/initialize_schur_complement_solver.cxx
+++ b/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/initialize_schur_complement_solver.cxx
@@ -70,8 +70,7 @@ void initialize_schur_complement_solver(
   Block_Matrix &schur_off_diagonal, El::DistMatrix<El::BigFloat> &Q,
   Timers &timers)
 {
-  Scoped_Timer initialize_timer(timers,
-                                "run.step.initializeSchurComplementSolver");
+  Scoped_Timer initialize_timer(timers, "initializeSchurComplementSolver");
   // The Schur complement matrix S: a Block_Diagonal_Matrix with one
   // block for each 0 <= j < J.  SchurComplement.blocks[j] has dimension
   // (d_j+1)*m_j*(m_j+1)/2
@@ -83,8 +82,7 @@ void initialize_schur_complement_solver(
   compute_schur_complement(block_info, A_X_inv, A_Y, schur_complement, timers);
 
   {
-    Scoped_Timer Q_computation_timer(
-    timers, "run.step.initializeSchurComplementSolver.Q");
+    Scoped_Timer Q_computation_timer(timers, "Q");
     // FIXME: Change initialize_Q_group to initialize_Q and
     // synchronize inside.
     El::DistMatrix<El::BigFloat> Q_group(Q.Height(), Q.Width(), group_grid);
@@ -93,7 +91,6 @@ void initialize_schur_complement_solver(
     synchronize_Q(Q, Q_group, timers);
   }
 
-  Scoped_Timer Cholesky_timer(
-    timers, "run.step.initializeSchurComplementSolver.Cholesky");
+  Scoped_Timer Cholesky_timer(timers, "Cholesky_Q");
   Cholesky(El::UpperOrLowerNS::UPPER, Q);
 }

--- a/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/initialize_schur_complement_solver.cxx
+++ b/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/initialize_schur_complement_solver.cxx
@@ -82,10 +82,9 @@ void initialize_schur_complement_solver(
 
   compute_schur_complement(block_info, A_X_inv, A_Y, schur_complement, timers);
 
-  auto &Q_computation_timer(
-    timers.add_and_start("run.step.initializeSchurComplementSolver.Q"));
-
   {
+    Scoped_Timer Q_computation_timer(
+    timers, "run.step.initializeSchurComplementSolver.Q");
     // FIXME: Change initialize_Q_group to initialize_Q and
     // synchronize inside.
     El::DistMatrix<El::BigFloat> Q_group(Q.Height(), Q.Width(), group_grid);
@@ -93,11 +92,8 @@ void initialize_schur_complement_solver(
                        schur_complement_cholesky, Q_group, timers);
     synchronize_Q(Q, Q_group, timers);
   }
-  Q_computation_timer.stop();
 
-  auto &Cholesky_timer(
-    timers.add_and_start("run.step.initializeSchurComplementSolver."
-                         "Cholesky"));
+  Scoped_Timer Cholesky_timer(
+    timers, "run.step.initializeSchurComplementSolver.Cholesky");
   Cholesky(El::UpperOrLowerNS::UPPER, Q);
-  Cholesky_timer.stop();
 }

--- a/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/synchronize_Q.cxx
+++ b/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/synchronize_Q.cxx
@@ -23,8 +23,7 @@ namespace
 void synchronize_Q(El::DistMatrix<El::BigFloat> &Q,
                    const El::DistMatrix<El::BigFloat> &Q_group, Timers &timers)
 {
-  Scoped_Timer synchronize_Q_buffers_timer(
-    timers, "run.step.initializeSchurComplementSolver.Q.synchronize_Q");
+  Scoped_Timer timer(timers, "synchronize_Q");
 
   const int total_ranks(El::mpi::Size(El::mpi::COMM_WORLD));
   // Special case serial case

--- a/src/sdp_solve/SDP_Solver/run/step/step.cxx
+++ b/src/sdp_solve/SDP_Solver/run/step/step.cxx
@@ -56,7 +56,8 @@ void SDP_Solver::step(
   El::BigFloat &beta_corrector, El::BigFloat &primal_step_length,
   El::BigFloat &dual_step_length, bool &terminate_now, Timers &timers)
 {
-  Scoped_Timer step_timer(timers, "run.step");
+  Scoped_Timer step_timer(timers, "step");
+
   El::BigFloat beta_predictor;
 
   // Search direction: These quantities have the same structure
@@ -93,8 +94,7 @@ void SDP_Solver::step(
                                        schur_off_diagonal, Q, timers);
 
     // Compute the complementarity mu = Tr(X Y)/X.dim
-    Scoped_Timer frobenius_timer(timers,
-                                 "run.step.frobenius_product_symmetric");
+    Scoped_Timer frobenius_timer(timers, "frobenius_product_symmetric");
     mu = frobenius_product_symmetric(X, Y) / total_psd_rows;
     frobenius_timer.stop();
     if(mu > parameters.max_complementarity)
@@ -104,8 +104,8 @@ void SDP_Solver::step(
       }
 
     {
-      Scoped_Timer predictor_timer(
-        timers, "run.step.computeSearchDirection(betaPredictor)");
+      Scoped_Timer predictor_timer(timers,
+                                   "computeSearchDirection(betaPredictor)");
 
       // Compute the predictor solution for (dx, dX, dy, dY)
       beta_predictor = predictor_centering_parameter(
@@ -117,8 +117,8 @@ void SDP_Solver::step(
     }
 
     // Compute the corrector solution for (dx, dX, dy, dY)
-    Scoped_Timer corrector_timer(
-      timers, "run.step.computeSearchDirection(betaCorrector)");
+    Scoped_Timer corrector_timer(timers,
+                                 "computeSearchDirection(betaCorrector)");
     beta_corrector = corrector_centering_parameter(
       parameters, X, dX, Y, dY, mu, is_primal_and_dual_feasible,
       total_psd_rows);
@@ -130,11 +130,11 @@ void SDP_Solver::step(
   // Compute step-lengths that preserve positive definiteness of X, Y
   primal_step_length
     = step_length(X_cholesky, dX, parameters.step_length_reduction,
-                  "run.step.stepLength(XCholesky)", timers);
+                  "stepLength(XCholesky)", timers);
 
   dual_step_length
     = step_length(Y_cholesky, dY, parameters.step_length_reduction,
-                  "run.step.stepLength(YCholesky)", timers);
+                  "stepLength(YCholesky)", timers);
 
   // If our problem is both dual-feasible and primal-feasible,
   // ensure we're following the true Newton direction.

--- a/src/sdp_solve/SDP_Solver/run/step/step.cxx
+++ b/src/sdp_solve/SDP_Solver/run/step/step.cxx
@@ -93,8 +93,8 @@ void SDP_Solver::step(
                                        schur_off_diagonal, Q, timers);
 
     // Compute the complementarity mu = Tr(X Y)/X.dim
-    auto &frobenius_timer(
-      timers.add_and_start("run.step.frobenius_product_symmetric"));
+    Scoped_Timer frobenius_timer(timers,
+                                 "run.step.frobenius_product_symmetric");
     mu = frobenius_product_symmetric(X, Y) / total_psd_rows;
     frobenius_timer.stop();
     if(mu > parameters.max_complementarity)
@@ -103,20 +103,22 @@ void SDP_Solver::step(
         return;
       }
 
-    auto &predictor_timer(
-      timers.add_and_start("run.step.computeSearchDirection(betaPredictor)"));
+    {
+      Scoped_Timer predictor_timer(
+        timers, "run.step.computeSearchDirection(betaPredictor)");
 
-    // Compute the predictor solution for (dx, dX, dy, dY)
-    beta_predictor
-      = predictor_centering_parameter(parameters, is_primal_and_dual_feasible);
-    compute_search_direction(block_info, sdp, *this, schur_complement_cholesky,
-                             schur_off_diagonal, X_cholesky, beta_predictor,
-                             mu, primal_residue_p, false, Q, dx, dX, dy, dY);
-    predictor_timer.stop();
+      // Compute the predictor solution for (dx, dX, dy, dY)
+      beta_predictor = predictor_centering_parameter(
+        parameters, is_primal_and_dual_feasible);
+      compute_search_direction(block_info, sdp, *this,
+                               schur_complement_cholesky, schur_off_diagonal,
+                               X_cholesky, beta_predictor, mu,
+                               primal_residue_p, false, Q, dx, dX, dy, dY);
+    }
 
     // Compute the corrector solution for (dx, dX, dy, dY)
-    auto &corrector_timer(
-      timers.add_and_start("run.step.computeSearchDirection(betaCorrector)"));
+    Scoped_Timer corrector_timer(
+      timers, "run.step.computeSearchDirection(betaCorrector)");
     beta_corrector = corrector_centering_parameter(
       parameters, X, dX, Y, dY, mu, is_primal_and_dual_feasible,
       total_psd_rows);
@@ -124,7 +126,6 @@ void SDP_Solver::step(
     compute_search_direction(block_info, sdp, *this, schur_complement_cholesky,
                              schur_off_diagonal, X_cholesky, beta_corrector,
                              mu, primal_residue_p, true, Q, dx, dX, dy, dY);
-    corrector_timer.stop();
   }
   // Compute step-lengths that preserve positive definiteness of X, Y
   primal_step_length

--- a/src/sdp_solve/SDP_Solver/run/step/step_length/step_length.cxx
+++ b/src/sdp_solve/SDP_Solver/run/step/step_length/step_length.cxx
@@ -30,13 +30,11 @@ El::BigFloat step_length(const Block_Diagonal_Matrix &MCholesky,
                          const std::string &timer_name,
                          Timers &timers)
 {
-  auto &step_length_timer(
-        timers.add_and_start(timer_name));
+  Scoped_Timer step_length_timer(timers, timer_name);
   // MInvDM = L^{-1} dM L^{-T}, where M = L L^T
   Block_Diagonal_Matrix MInvDM(dM);
   lower_triangular_inverse_congruence(MCholesky, MInvDM);
   const El::BigFloat lambda(min_eigenvalue(MInvDM));
-  step_length_timer.stop();
   if(lambda > -gamma)
     {
       return 1;

--- a/src/sdpb/main.cxx
+++ b/src/sdpb/main.cxx
@@ -86,8 +86,14 @@ int main(int argc, char **argv)
             parameters.proc_granularity, parameters.verbosity);
           std::swap(block_info, new_info);
 
+          auto runtime_it
+            = std::find_if(timers.begin(), timers.end(),
+                           [](std::pair<std::string, Timer> item) {
+                             return item.first == "Solver runtime";
+                           });
+          assert(runtime_it != timers.end());
           parameters.solver.max_runtime
-            -= timers.front().second.elapsed_seconds();
+            -= runtime_it->second.elapsed_seconds();
         }
       else if(!block_info.block_timings_filename.empty()
               && block_info.block_timings_filename

--- a/src/sdpb/main.cxx
+++ b/src/sdpb/main.cxx
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
           auto runtime_it
             = std::find_if(timers.begin(), timers.end(),
                            [](std::pair<std::string, Timer> item) {
-                             return item.first == "Solver runtime";
+                             return item.first == "sdpb.solve.run";
                            });
           assert(runtime_it != timers.end());
           parameters.solver.max_runtime

--- a/src/sdpb/save_solution.cxx
+++ b/src/sdpb/save_solution.cxx
@@ -2,9 +2,6 @@
 #include "../set_stream_precision.hxx"
 #include "../write_distmatrix.hxx"
 
-
-#include <iomanip>
-
 namespace fs = std::filesystem;
 
 namespace
@@ -62,8 +59,8 @@ void save_solution(const SDP_Solver &solver,
                  << "dualityGap      = " << solver.duality_gap << ";\n"
                  << "primalError     = " << solver.primal_error() << ";\n"
                  << "dualError       = " << solver.dual_error << ";\n"
-                 << std::setw(16) << std::left << timer_pair.first << "= "
-                 << timer_pair.second.elapsed_seconds() << ";\n";
+                 << "Solver runtime  = " << timer_pair.second.elapsed_seconds()
+                 << ";\n";
       if(!out_stream.good())
         {
           throw std::runtime_error("Error when writing to: "

--- a/src/sdpb/solve.cxx
+++ b/src/sdpb/solve.cxx
@@ -48,7 +48,12 @@ Timers solve(const Block_Info &block_info, const SDPB_Parameters &parameters)
       solver.save_checkpoint(parameters.solver.checkpoint_out, parameters.verbosity,
                              parameters_tree);
     }
-  save_solution(solver, reason, timers.front(), parameters.out_directory,
+  auto runtime_it = std::find_if(timers.begin(), timers.end(),
+                                 [](std::pair<std::string, Timer> item) {
+                                   return item.first == "Solver runtime";
+                                 });
+  assert(runtime_it != timers.end());
+  save_solution(solver, reason, *runtime_it, parameters.out_directory,
                 parameters.write_solution, block_info.block_indices,
                 parameters.verbosity);
   return timers;


### PR DESCRIPTION
Summary:
- Rewrote `ScopedTimer` to ensure that nested timers will have correct prefixes, see changes in `Timers.hxx`. Also added asserts to ensure that nested timer always stops before parent.
- Added some new timers, e.g. `"sdpb.solve.run.iter_XXX"` for each solver iteration.
- Renamed some timers, e.g. for `sdp2input`.
- Fixed `Timer::elapsed_milliseconds()`: show correct time even if timer is still running.

`ScopedTimer` now temporarily adds its name to `Timers::prefix`.
Example:
```
void f()
{
  Timers timers(false);
  Scoped_Timer root_timer(timers, "root"); // "root"
  Scoped_Timer x_timer(timers, "x"); // "root.x"
  x_timer.stop();
  Scoped_Timer y_timer(timers, "y"); // "root.y"
  {
    Scoped_Timer yy_timer(timers, "yy"); // "root.y.yy"
  }
  Scoped_Timer z_timer(timers, "z"); // "root.y.z"
}
```

The only change to SDPB behaviour is timer names printed to `profiling.*` in debug mode. Beside that, this PR is mainly about improving code quality.