### PR TITLE
Fix #148 Binary SDP format is larger than json format if blocks contain many zeros

### DIFF
--- a/test/src/unit_tests/cases/block_data_serialization.test.cxx
+++ b/test/src/unit_tests/cases/block_data_serialization.test.cxx
@@ -8,6 +8,7 @@
 using Test_Util::random_bigfloat;
 using Test_Util::random_matrix;
 using Test_Util::random_vector;
+using Test_Util::zero_matrix;
 using Test_Util::REQUIRE_Equal::diff;
 
 void write_block_data(std::ostream &os, const Dual_Constraint_Group &group,
@@ -62,6 +63,22 @@ namespace
     group.bilinear_bases[1] = random_matrix(12, 24);
     return group;
   }
+
+  // Dual_Constraint_Group with the same sizes as block_0 in integration test
+  // end-to-end_tests/SingletScalar_cT_test_nmax6/primal_dual_optimal
+  Dual_Constraint_Group zero_group_from_singlet_scalar_block_0()
+  {
+    Dual_Constraint_Group group;
+    group.dim = 1;
+    group.num_points = 24;
+    int P = 24;
+    int N = 20;
+    group.constraint_matrix = zero_matrix(P, N);
+    group.constraint_constants = std::vector<El::BigFloat>(P, 0);
+    group.bilinear_bases[0] = zero_matrix(12, 24);
+    group.bilinear_bases[1] = zero_matrix(12, 24);
+    return group;
+  }
 }
 
 TEST_CASE("block_data serialization")
@@ -72,12 +89,15 @@ TEST_CASE("block_data serialization")
 
   El::InitializeRandom(true);
   Dual_Constraint_Group group = random_group_from_singlet_scalar_block_0();
+  Dual_Constraint_Group zero_group = zero_group_from_singlet_scalar_block_0();
 
   Block_File_Format format = GENERATE(bin, json);
   DYNAMIC_SECTION((format == bin ? ".bin" : ".json"))
   {
     auto other = serialize_deserialize(group, format);
     DIFF(group, other);
+    other = serialize_deserialize(zero_group, format);
+    DIFF(zero_group, other);
   }
 }
 
@@ -89,11 +109,14 @@ TEST_CASE("benchmark block_data write+parse", "[!benchmark]")
 
   El::InitializeRandom(true);
   Dual_Constraint_Group group = random_group_from_singlet_scalar_block_0();
+  Dual_Constraint_Group zero_group = zero_group_from_singlet_scalar_block_0();
 
   // Change constraint_matrix size to see how bin/json scales
   int B_width = GENERATE(20, 100, 1000, 10000);
   group.constraint_matrix
     = random_matrix(group.constraint_matrix.Height(), B_width);
+  zero_group.constraint_matrix
+    = zero_matrix(zero_group.constraint_matrix.Height(), B_width);
 
   int total_count = 0;
   total_count += group.constraint_constants.size();
@@ -108,8 +131,19 @@ TEST_CASE("benchmark block_data write+parse", "[!benchmark]")
     // We could put this benchmarks into different DYNAMIC_SECTION's,
     // using Block_File_Format format = GENERATE(bin, json);
     // But it would make output less concise
-    BENCHMARK("write+parse bin") { return serialize_deserialize(group, bin); };
-    BENCHMARK("write+parse JSON")
+    BENCHMARK("write+parse bin zero")
+    {
+      return serialize_deserialize(zero_group, bin);
+    };
+    BENCHMARK("write+parse bin nonzero")
+    {
+      return serialize_deserialize(group, bin);
+    };
+    BENCHMARK("write+parse JSON zero")
+    {
+      return serialize_deserialize(zero_group, json);
+    };
+    BENCHMARK("write+parse JSON nonzero")
     {
       return serialize_deserialize(group, json);
     };

--- a/test/src/unit_tests/util/util.hxx
+++ b/test/src/unit_tests/util/util.hxx
@@ -38,4 +38,11 @@ namespace Test_Util
 
     return matrix;
   }
+
+  inline El::Matrix<El::BigFloat> zero_matrix(int height, int width)
+  {
+    El::Matrix<El::BigFloat> zeros(height, width);
+    El::Zero(zeros);
+    return zeros;
+  }
 }


### PR DESCRIPTION
(See also discussion in #148)

If BigFloat is zero, then we write only boolean flag indicating it. If not, we write the flag(=false) and then serialized bytes.
This makes zeros ~100x more compact (for precision=768, BigFloat needs ~100B).

Results for GNY model, nmax=8:
sdp.zip size and archiving time (on Expanse HPC):
```
JSON format:                      2.1GB, 8.4s
Binary format before this change: 4.0GB, 16.1s
Binary format after this change:  0.9GB, 4.0s
```

P.S. Benchmarks on my laptop for **in-memory** serialization/deserialization (note that in real problems IO is a bottleneck, as we see from the numbers above):
```
benchmark block_data write+parse
  240600 BigFloats
-------------------------------------------------------------------------------
../test/src/unit_tests/cases/block_data_serialization.test.cxx:129
...............................................................................

benchmark name                            samples    iterations          mean
-------------------------------------------------------------------------------
write+parse bin zero                             3             1    37.2142 ms 
write+parse bin nonzero                          3             1    53.4107 ms 
write+parse JSON zero                            3             1    148.829 ms 
write+parse JSON nonzero                         3             1     1.06913 s 
```