### PR TITLE
Fix #159 Memory leak in binary SDP deserialization

### DIFF
--- a/src/sdpb_util/boost_serialization.hxx
+++ b/src/sdpb_util/boost_serialization.hxx
@@ -78,11 +78,10 @@ namespace boost::serialization
     ar & height;
     ar & width;
     ar & leadingDimension;
+    matrix.Resize(height, width, leadingDimension);
     auto size = leadingDimension * width;
-    Ring *buffer = new Ring[size];
-    auto data = boost::serialization::make_array(buffer, size);
+    auto data = boost::serialization::make_array(matrix.Buffer(), size);
     ar & data;
-    matrix.Control(height, width, buffer, leadingDimension);
   }
 }
 

--- a/src/sdpb_util/boost_serialization.hxx
+++ b/src/sdpb_util/boost_serialization.hxx
@@ -88,3 +88,10 @@ namespace boost::serialization
 BOOST_CLASS_VERSION(El::BigFloat, 1)
 
 BOOST_SERIALIZATION_SPLIT_FREE(El::Matrix<El::BigFloat>)
+
+// https://www.boost.org/doc/libs/1_82_0/libs/serialization/doc/special.html#objecttracking
+// We are just writing arrays, don't need the object tracking mechanism,
+// which may cause memory issues (according to some StackOverflow questions).
+BOOST_CLASS_TRACKING(El::BigFloat, boost::serialization::track_never)
+BOOST_CLASS_TRACKING(El::Matrix<El::BigFloat>,
+                     boost::serialization::track_never)


### PR DESCRIPTION
See #159 
Memory leak was caused by bug in `El::Matrix::Control()`, so we don't use this method now.

I also disabled [Object tracking](https://www.boost.org/doc/libs/1_82_0/libs/serialization/doc/special.html#objecttracking) in boost serialization for out types.
This mechanism may sometimes cause memory issues (according to some StackOverflow questions), and we don't need it - we are simply reading/writing arrays.