### PR TITLE
Improve debug mode output: print MemUsed and MemTotal for each node, disable proc/self/statm

### DIFF
--- a/src/sdpb/main.cxx
+++ b/src/sdpb/main.cxx
@@ -82,8 +82,6 @@ int main(int argc, char **argv)
           write_timing(timing_parameters.solver.checkpoint_out, block_info,
                        timers, timing_parameters.verbosity >= Verbosity::debug,
                        block_timings);
-          if(timing_parameters.verbosity >= Verbosity::debug)
-            timers.print_max_mem_used();
           El::mpi::Barrier(El::mpi::COMM_WORLD);
           Block_Info new_info(
             parameters.sdp_path, block_timings, parameters.procs_per_node,
@@ -109,8 +107,6 @@ int main(int argc, char **argv)
             }
         }
       Timers timers(solve(block_info, parameters, start_time));
-      if(parameters.verbosity >= Verbosity::debug)
-        timers.print_max_mem_used();
     }
   catch(std::exception &e)
     {

--- a/src/sdpb/main.cxx
+++ b/src/sdpb/main.cxx
@@ -82,6 +82,8 @@ int main(int argc, char **argv)
           write_timing(timing_parameters.solver.checkpoint_out, block_info,
                        timers, timing_parameters.verbosity >= Verbosity::debug,
                        block_timings);
+          if(timing_parameters.verbosity >= Verbosity::debug)
+            timers.print_max_mem_used();
           El::mpi::Barrier(El::mpi::COMM_WORLD);
           Block_Info new_info(
             parameters.sdp_path, block_timings, parameters.procs_per_node,
@@ -106,7 +108,9 @@ int main(int argc, char **argv)
                         fs::copy_options::overwrite_existing);
             }
         }
-      solve(block_info, parameters, start_time);
+      Timers timers(solve(block_info, parameters, start_time));
+      if(parameters.verbosity >= Verbosity::debug)
+        timers.print_max_mem_used();
     }
   catch(std::exception &e)
     {

--- a/src/sdpb_util/Proc_Meminfo.cxx
+++ b/src/sdpb_util/Proc_Meminfo.cxx
@@ -1,0 +1,83 @@
+#include "Proc_Meminfo.hxx"
+
+#include <El.hpp>
+
+#include <fstream>
+#include <sstream>
+
+Proc_Meminfo::Proc_Meminfo(size_t mem_total, size_t mem_available)
+    : mem_total(mem_total), mem_available(mem_available)
+{}
+
+size_t Proc_Meminfo::mem_used() const
+{
+  return mem_total - mem_available;
+}
+
+Proc_Meminfo Proc_Meminfo::try_read(bool &result) noexcept
+{
+  try
+    {
+      const auto meminfo = read();
+      result = true;
+      return meminfo;
+    }
+  catch(...)
+    {
+      result = false;
+      return {0, 0};
+    }
+}
+
+Proc_Meminfo Proc_Meminfo::read() noexcept(false)
+{
+  auto proc_meminfo_path = "/proc/meminfo";
+  std::ifstream meminfo_file(proc_meminfo_path);
+
+  if(!meminfo_file.good())
+    El::RuntimeError("Cannot read ", proc_meminfo_path);
+
+  const char *mem_total_prefix = "MemTotal:";
+  const char *mem_available_prefix = "MemAvailable:";
+  size_t memTotalKB = 0;
+  size_t memAvailableKB = 0;
+  std::string line;
+  while(std::getline(meminfo_file, line))
+    {
+      std::istringstream iss(line);
+      std::string name;
+      size_t size;
+      std::string kB;
+      if(iss >> name >> size >> kB)
+        {
+          if(kB != "kB" && kB != "KB")
+            {
+              El::RuntimeError(proc_meminfo_path,
+                               ": expected \"kB\" at the end of line: ", line);
+            }
+          if(name == mem_total_prefix)
+            memTotalKB = size;
+          else if(name == mem_available_prefix)
+            memAvailableKB = size;
+          if(memTotalKB > 0 && memAvailableKB > 0)
+            break;
+        }
+      else
+        {
+          El::RuntimeError(proc_meminfo_path, ": cannot parse line: ", line);
+        }
+    }
+
+  if(memTotalKB == 0)
+    {
+      El::RuntimeError(proc_meminfo_path, ": ", mem_total_prefix,
+                       " not found");
+    }
+  if(memAvailableKB == 0)
+    {
+      El::RuntimeError(proc_meminfo_path, ": ", mem_available_prefix,
+                       " not found");
+    }
+
+  return {memTotalKB * 1024, memAvailableKB * 1024};
+}

--- a/src/sdpb_util/Proc_Meminfo.cxx
+++ b/src/sdpb_util/Proc_Meminfo.cxx
@@ -14,7 +14,7 @@ size_t Proc_Meminfo::mem_used() const
   return mem_total - mem_available;
 }
 
-Proc_Meminfo Proc_Meminfo::try_read(bool &result) noexcept
+Proc_Meminfo Proc_Meminfo::try_read(bool &result, bool print_error_msg) noexcept
 {
   try
     {
@@ -22,9 +22,18 @@ Proc_Meminfo Proc_Meminfo::try_read(bool &result) noexcept
       result = true;
       return meminfo;
     }
+  catch(std::exception& e)
+    {
+      result = false;
+      if(print_error_msg)
+        El::Output("Failed to parse /proc/meminfo: ", e.what());
+      return {0, 0};
+    }
   catch(...)
     {
       result = false;
+      if(print_error_msg)
+        El::Output("Failed to parse /proc/meminfo");
       return {0, 0};
     }
 }
@@ -35,7 +44,7 @@ Proc_Meminfo Proc_Meminfo::read() noexcept(false)
   std::ifstream meminfo_file(proc_meminfo_path);
 
   if(!meminfo_file.good())
-    El::RuntimeError("Cannot read ", proc_meminfo_path);
+    El::RuntimeError("Cannot open ", proc_meminfo_path);
 
   const char *mem_total_prefix = "MemTotal:";
   const char *mem_available_prefix = "MemAvailable:";

--- a/src/sdpb_util/Proc_Meminfo.hxx
+++ b/src/sdpb_util/Proc_Meminfo.hxx
@@ -26,7 +26,8 @@ struct Proc_Meminfo
   // read from /proc/meminfo, NB: can throw exceptions
   static Proc_Meminfo read() noexcept(false);
   // read from /proc/meminfo, in case of exception catch it and set result = false
-  static Proc_Meminfo try_read(bool &result) noexcept;
+  static Proc_Meminfo
+  try_read(bool &result, bool print_error_msg = false) noexcept;
 
 private:
   Proc_Meminfo(size_t mem_total, size_t mem_available);

--- a/src/sdpb_util/Proc_Meminfo.hxx
+++ b/src/sdpb_util/Proc_Meminfo.hxx
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstddef>
+
+// This class displays data read from /proc/meminfo
+//
+// /proc/meminfo can be different on different OSs.
+// Usually (e.g. on CentOS) it looks like
+// MemTotal:       131189996 kB
+// MemFree:        24211752 kB
+// MemAvailable:   69487008 kB
+// ...
+// We store all values in bytes.
+struct Proc_Meminfo
+{
+  // MemTotal, B
+  const size_t mem_total;
+  // MemAvailable, B (RAM available for allocation)
+  const size_t mem_available;
+
+  // MemUsed (bytes) is defined as MemUsed = MemTotal - MemAvailable.
+  // MemUsed is RAM that is occupied by all processes and cannot be released
+  // (i.e. it doesn't include cache)
+  [[nodiscard]] size_t mem_used() const;
+
+  // read from /proc/meminfo, NB: can throw exceptions
+  static Proc_Meminfo read() noexcept(false);
+  // read from /proc/meminfo, in case of exception catch it and set result = false
+  static Proc_Meminfo try_read(bool &result) noexcept;
+
+private:
+  Proc_Meminfo(size_t mem_total, size_t mem_available);
+};

--- a/src/sdpb_util/Timers/Timers.cxx
+++ b/src/sdpb_util/Timers/Timers.cxx
@@ -40,8 +40,8 @@ Timer &Timers::add_and_start(const std::string &name)
   if(debug)
     print_meminfo(full_name);
 
-  emplace_back(full_name, Timer());
-  return back().second;
+  named_timers.emplace_back(full_name, Timer());
+  return named_timers.back().second;
 }
 void Timers::write_profile(const std::filesystem::path &path) const
 {
@@ -50,11 +50,11 @@ void Timers::write_profile(const std::filesystem::path &path) const
   std::ofstream f(path);
 
   f << "{" << '\n';
-  for(auto it(begin()); it != end();)
+  for(auto it(named_timers.begin()); it != named_timers.end();)
     {
       f << "    {\"" << it->first << "\", " << it->second << "}";
       ++it;
-      if(it != end())
+      if(it != named_timers.end())
         {
           f << ",";
         }
@@ -69,11 +69,11 @@ void Timers::write_profile(const std::filesystem::path &path) const
 }
 int64_t Timers::elapsed_milliseconds(const std::string &s) const
 {
-  auto iter(std::find_if(rbegin(), rend(),
+  auto iter(std::find_if(named_timers.rbegin(), named_timers.rend(),
                          [&s](const std::pair<std::string, Timer> &timer) {
                            return timer.first == s;
                          }));
-  if(iter == rend())
+  if(iter == named_timers.rend())
     {
       throw std::runtime_error("Could not find timing for " + s);
     }
@@ -118,7 +118,7 @@ void Timers::print_meminfo(const std::string &name)
     }
 
   // MemTotal is constant, thus we print it only once, when adding first timer
-  if(empty())
+  if(named_timers.empty())
     {
       El::Output(prefix, "--- MemTotal: ", to_GB(meminfo.mem_total), " GB");
     }

--- a/src/sdpb_util/Timers/Timers.cxx
+++ b/src/sdpb_util/Timers/Timers.cxx
@@ -97,13 +97,23 @@ void Timers::print_meminfo(const std::string &name)
 
   auto prefix = El::BuildString(El::mpi::Rank(), " ", name, " ");
 
-  // Print memory usage for each node (at first rank)
+  // Print memory usage for the current node (from the first rank).
+  // If we cannot parse /proc/meminfo, then simply print timer name.
+
+  if(!can_read_meminfo)
+    {
+      El::Output(prefix);
+      return;
+    }
 
   bool result;
-  const auto meminfo = Proc_Meminfo::try_read(result);
+  constexpr bool print_error_msg = true;
+  const auto meminfo = Proc_Meminfo::try_read(result, print_error_msg);
   if(!result)
     {
-      El::Output(prefix, "cannot parse /proc/meminfo");
+      can_read_meminfo = false;
+      El::Output("Printing RAM usage will be disabled.");
+      El::Output(prefix);
       return;
     }
 

--- a/src/sdpb_util/Timers/Timers.cxx
+++ b/src/sdpb_util/Timers/Timers.cxx
@@ -33,6 +33,20 @@ Timers::Timers(bool debug) : debug(debug)
   MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
                       &comm_shared_mem.comm);
 }
+
+Timers::~Timers() noexcept
+{
+  try
+    {
+      if(debug)
+        print_max_mem_used();
+    }
+  catch(...)
+    {
+      // destructors should never throw exceptions
+    }
+}
+
 Timer &Timers::add_and_start(const std::string &name)
 {
   std::string full_name = prefix + name;

--- a/src/sdpb_util/Timers/Timers.cxx
+++ b/src/sdpb_util/Timers/Timers.cxx
@@ -120,11 +120,11 @@ void Timers::print_meminfo(const std::string &name)
   // MemTotal is constant, thus we print it only once, when adding first timer
   if(empty())
     {
-      El::Output(prefix, "MemTotal: ", to_GB(meminfo.mem_total), " GB");
+      El::Output(prefix, "--- MemTotal: ", to_GB(meminfo.mem_total), " GB");
     }
 
   //Print MemUsed each time
-  El::Output(prefix, "MemUsed: ", to_GB(meminfo.mem_used()), " GB");
+  El::Output(prefix, "--- MemUsed: ", to_GB(meminfo.mem_used()), " GB");
 
   // Update max MemUsed info
   if(meminfo.mem_used() > max_mem_used)

--- a/src/sdpb_util/Timers/Timers.hxx
+++ b/src/sdpb_util/Timers/Timers.hxx
@@ -27,6 +27,10 @@ private:
   // Shared memory communicator, used for debug output.
   // TODO: create it somewhere near El::Environment and reuse in other places,
   El::mpi::Comm comm_shared_mem;
+  // Max MemUsed value
+  size_t max_mem_used{};
+  // name of the timer that had max MemUsed value
+  std::string max_mem_used_name;
 
 public:
   explicit Timers(bool debug);
@@ -38,6 +42,11 @@ public:
   void write_profile(const std::filesystem::path &path) const;
 
   int64_t elapsed_milliseconds(const std::string &s) const;
+
+  void print_max_mem_used() const;
+
+private:
+  void print_meminfo(const std::string &name);
 };
 
 // Simple RAII timer

--- a/src/sdpb_util/Timers/Timers.hxx
+++ b/src/sdpb_util/Timers/Timers.hxx
@@ -39,6 +39,7 @@ private:
 
 public:
   explicit Timers(bool debug);
+  ~Timers() noexcept;
 
 private:
   Timer &add_and_start(const std::string &name);
@@ -48,9 +49,8 @@ public:
 
   int64_t elapsed_milliseconds(const std::string &s) const;
 
-  void print_max_mem_used() const;
-
 private:
+  void print_max_mem_used() const;
   void print_meminfo(const std::string &name);
 };
 

--- a/src/sdpb_util/Timers/Timers.hxx
+++ b/src/sdpb_util/Timers/Timers.hxx
@@ -13,11 +13,8 @@
 
 #include <boost/core/noncopyable.hpp>
 
-#include <cassert>
-#include <fstream>
 #include <string>
 #include <list>
-#include <algorithm>
 #include <filesystem>
 
 struct Timers : public std::list<std::pair<std::string, Timer>>
@@ -27,6 +24,9 @@ struct Timers : public std::list<std::pair<std::string, Timer>>
 private:
   const bool debug = false;
   std::string prefix;
+  // Shared memory communicator, used for debug output.
+  // TODO: create it somewhere near El::Environment and reuse in other places,
+  El::mpi::Comm comm_shared_mem;
 
 public:
   explicit Timers(bool debug);

--- a/src/sdpb_util/Timers/Timers.hxx
+++ b/src/sdpb_util/Timers/Timers.hxx
@@ -17,11 +17,15 @@
 #include <list>
 #include <filesystem>
 
-struct Timers : public std::list<std::pair<std::string, Timer>>
+struct Timers
 {
   friend struct Scoped_Timer; // can change private field prefix
 
 private:
+  // We use std::list instead of std::vector to avoid reallocation.
+  // Scoped_Timer holds reference to timer, which would be invalidated after reallocation.
+  // TODO refactor timers in a way that prevents such obscure bugs.
+  std::list<std::pair<std::string, Timer>> named_timers;
   const bool debug = false;
   std::string prefix;
   // Shared memory communicator, used for debug output.

--- a/src/sdpb_util/Timers/Timers.hxx
+++ b/src/sdpb_util/Timers/Timers.hxx
@@ -27,6 +27,7 @@ private:
   // Shared memory communicator, used for debug output.
   // TODO: create it somewhere near El::Environment and reuse in other places,
   El::mpi::Comm comm_shared_mem;
+  bool can_read_meminfo = true;
   // Max MemUsed value
   size_t max_mem_used{};
   // name of the timer that had max MemUsed value

--- a/wscript
+++ b/wscript
@@ -23,6 +23,7 @@ def build(bld):
     default_includes = ['src', 'external']
 
     bld.stlib(source=['src/sdpb_util/Mesh.cxx',
+                      'src/sdpb_util/Proc_Meminfo.cxx',
                       'src/sdpb_util/Timers/Scoped_Timer.cxx',
                       'src/sdpb_util/Timers/Timer.cxx',
                       'src/sdpb_util/Timers/Timers.cxx'],


### PR DESCRIPTION
Output from `Timers` when `debug = true`:
1. Print `MemUsed, GB` for the first rank of each node at each timer start, see #158.
2. Add separator `---` between timer name and `MemUsed` for better readability
3. #162 
4. Print `MemTotal, GB` when adding a first timer (it is constant, so we need to print in only once).
5. Do not print `proc/self/statm`. Previously, we printed each for each timer for each rank. As a result, SDPB output became too verbose and hard to read. I found that I never used `statm` in practice - `MemUsed` per node is enough for tracking progress and RAM usage.