### PR TITLE
Fix #166 Incorrect block mapping for cyclic MPI job distribution across nodes

### DIFF
--- a/src/sdp_solve/Block_Cost.hxx
+++ b/src/sdp_solve/Block_Cost.hxx
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <vector>
-#include <cstdio>
+#include <cstddef>
+#include <tuple>
 
 struct Block_Cost
 {
@@ -11,5 +11,8 @@ struct Block_Cost
       : cost(Cost == 0 ? 1 : Cost), index(Index)
   {}
   Block_Cost() = delete;
-  bool operator<(const Block_Cost &b) const { return cost < b.cost; }
+  bool operator<(const Block_Cost &b) const
+  {
+    return std::tie(cost, index) < std::tie(b.cost, b.index);
+  }
 };

--- a/src/sdp_solve/Block_Info/allocate_blocks/Block_Map.hxx
+++ b/src/sdp_solve/Block_Info/allocate_blocks/Block_Map.hxx
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <vector>
 
 struct Block_Map
@@ -23,6 +24,14 @@ struct Block_Map
   // Sort by average cost
   bool operator<(const Block_Map &b) const
   {
-    return cost * b.num_procs < b.cost * num_procs;
+    return std::make_tuple(cost * b.num_procs, first_index())
+           < std::make_tuple(b.cost * num_procs, b.first_index());
+  }
+
+private:
+  [[nodiscard]] size_t first_index() const
+  {
+    return block_indices.empty() ? std::numeric_limits<size_t>::max()
+                                 : block_indices.at(0);
   }
 };

--- a/src/sdp_solve/Block_Info/allocate_blocks/allocate_blocks.cxx
+++ b/src/sdp_solve/Block_Info/allocate_blocks/allocate_blocks.cxx
@@ -55,21 +55,22 @@ void Block_Info::allocate_blocks(const Environment &env,
     {
       std::stringstream ss;
       ss << "Block Grid Mapping\n"
-         << "Node\tNum Procs\tCost\t\tBlock List\n"
-         << "==================================================\n";
+         << "Node\tNum Procs\tCost (Per Proc)\t\tBlock List\n"
+         << "==========================================================\n";
       for(size_t node = 0; node < mapping.size(); ++node)
         {
           for(auto &m : mapping[node])
             {
               ss << node << "\t" << m.num_procs << "\t\t"
-                 << m.cost / static_cast<double>(m.num_procs) << "\t{";
+                 << m.cost / static_cast<double>(m.num_procs) << "\t\t\t{";
               for(size_t ii = 0; ii < m.block_indices.size(); ++ii)
                 {
                   if(ii != 0)
                     {
-                      ss << ",";
+                      ss << ", ";
                     }
-                  ss << "(" << m.block_indices[ii] << ","
+                  ss << m.block_indices[ii] << "("
+                     << dimensions[m.block_indices[ii]] << ","
                      << num_points[m.block_indices[ii]] << ")";
                 }
               ss << "}\n";


### PR DESCRIPTION
- In `allocate_blocks()`, use ranks from node communicator instead of global ranks (which can be assigned to nodes in different ways), see details in #166
- Make `Block_Cost` comparison deterministic if costs are equal (compare block indices in that case).
- In Block Grid Mapping (debug output), print each block in `block_index(dim,num_points)` format, instead of old `(block_index,num_points)`