### PR TITLE
Print file and line number in exception, add ASSERT() and RUNTIME_ERROR() macros

### DIFF
--- a/src/approx_objective/Approx_Parameters/Approx_Parameters.cxx
+++ b/src/approx_objective/Approx_Parameters/Approx_Parameters.cxx
@@ -1,5 +1,7 @@
 #include "../Approx_Parameters.hxx"
 
+#include "sdpb_util/assert.hxx"
+
 #include <boost/program_options.hpp>
 
 namespace fs = std::filesystem;
@@ -57,8 +59,7 @@ Approx_Parameters::Approx_Parameters(int argc, char *argv[])
     "approx_objective to skip the time consuming part of setting up the "
     "solver.");
   basic_options.add_options()(
-    "linear",
-    po::bool_switch(&linear_only)->default_value(false),
+    "linear", po::bool_switch(&linear_only)->default_value(false),
     "Only compute the linear correction, not the quadratic correction.  "
     "This avoids having to compute an expensive inverse.");
 
@@ -90,12 +91,7 @@ Approx_Parameters::Approx_Parameters(int argc, char *argv[])
             {
               param_path = variables_map["paramFile"].as<fs::path>();
               std::ifstream ifs(param_path);
-              if(!ifs.good())
-                {
-                  throw std::runtime_error("Could not open '"
-                                           + param_path.string() + "'");
-                }
-
+              ASSERT(ifs.good(), "Could not open ", param_path);
               po::store(po::parse_config_file(ifs, cmd_line_options),
                         variables_map);
             }
@@ -109,17 +105,9 @@ Approx_Parameters::Approx_Parameters(int argc, char *argv[])
                          "automatically from MPI environment.");
             }
 
-          if(!fs::exists(sdp_path))
-            {
-              throw std::runtime_error("SDP path '" + sdp_path.string()
-                                       + "' does not exist");
-            }
-
-          if(!new_sdp_path.empty() && !fs::exists(new_sdp_path))
-            {
-              throw std::runtime_error("New SDP path '" + new_sdp_path.string()
-                                       + "' does not exist");
-            }
+          ASSERT(fs::exists(sdp_path), "SDP path does not exist: ", sdp_path);
+          ASSERT(new_sdp_path.empty() || fs::exists(new_sdp_path),
+                 "New SDP path does not exist: ", sdp_path);
 
           if(variables_map.count("solutionDir") == 0)
             {

--- a/src/outer_limits/Function/eval/chebyshev_clenshaw_recurrence.hxx
+++ b/src/outer_limits/Function/eval/chebyshev_clenshaw_recurrence.hxx
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "sdpb_util/assert.hxx"
+
 #include <cstddef>
 #include <stdexcept>
 #include <sstream>
@@ -113,16 +115,10 @@ inline Real unchecked_chebyshev_clenshaw_recurrence(const Real* const c, size_t 
 template<class Real>
 inline Real chebyshev_clenshaw_recurrence(const Real* const c, size_t length, const Real & a, const Real & b, const Real& x)
 {
-    if (x < a || x > b)
+  if(x < a || x > b)
     {
-      std::stringstream ss;
-      ss << "x in [a, b] is required: x = "
-         << x
-         << ", a = "
-         << a
-         << ", b = "
-         << b;
-      throw std::domain_error(ss.str());
+      THROW(std::domain_error, "x in [a, b] is required: x = ", x, ", a = ", a,
+            ", b = ", b);
     }
     if (length < 2)
     {

--- a/src/outer_limits/Outer_Parameters/Outer_Parameters.cxx
+++ b/src/outer_limits/Outer_Parameters/Outer_Parameters.cxx
@@ -1,5 +1,7 @@
 #include "../Outer_Parameters.hxx"
 
+#include "sdpb_util/assert.hxx"
+
 #include <boost/program_options.hpp>
 
 namespace fs = std::filesystem;
@@ -88,11 +90,7 @@ Outer_Parameters::Outer_Parameters(int argc, char *argv[])
           if(variables_map.count("paramFile") != 0)
             {
               std::ifstream param_file(param_path);
-              if(!param_file.good())
-                {
-                  throw std::runtime_error("Could not open '"
-                                           + param_path.string() + "'");
-                }
+              ASSERT(param_file.good(), "Could not open ", param_path);
 
               po::store(po::parse_config_file(param_file, cmd_line_options),
                         variables_map);
@@ -100,18 +98,11 @@ Outer_Parameters::Outer_Parameters(int argc, char *argv[])
 
           po::notify(variables_map);
 
-          if(!fs::exists(functions_path))
-            {
-              throw std::runtime_error("functions path '"
-                                       + functions_path.string()
-                                       + "' does not exist");
-            }
-          if(fs::is_directory(functions_path))
-            {
-              throw std::runtime_error("functions path '"
-                                       + functions_path.string()
-                                       + "' is a directory, not a file.");
-            }
+          ASSERT(fs::exists(functions_path),
+                 "functions path does not exist: ", functions_path);
+          ASSERT(
+            !fs::is_directory(functions_path),
+            "functions path is a directory, not a file: ", functions_path);
 
           if(variables_map.count("out") == 0)
             {
@@ -145,11 +136,7 @@ Outer_Parameters::Outer_Parameters(int argc, char *argv[])
             {
               fs::create_directories(output_path.parent_path());
               std::ofstream ofs(output_path);
-              if(!ofs.good())
-                {
-                  throw std::runtime_error("Cannot write to outDir: "
-                                           + output_path.string());
-                }
+              ASSERT(ofs.good(), "Cannot write to outDir: ", output_path);
             }
         }
     }

--- a/src/outer_limits/compute_optimal/compute_optimal.cxx
+++ b/src/outer_limits/compute_optimal/compute_optimal.cxx
@@ -2,6 +2,7 @@
 #include "setup_constraints.hxx"
 #include "outer_limits/Outer_Parameters.hxx"
 #include "pmp/max_normalization_index.hxx"
+#include "sdpb_util/assert.hxx"
 #include "sdpb_util/copy_matrix.hxx"
 #include "sdpb_util/fill_weights.hxx"
 #include "sdpb_util/ostream/ostream_map.hxx"
@@ -60,13 +61,10 @@ std::vector<El::BigFloat> compute_optimal(
   const Outer_Parameters &parameters_in,
   const std::chrono::time_point<std::chrono::high_resolution_clock> &start_time)
 {
-  if(initial_points.size() != function_blocks.size())
-    {
-      throw std::runtime_error("Size are different: Polynomial_Vector_Matrix: "
-                               + std::to_string(function_blocks.size())
-                               + ", initial points: "
-                               + std::to_string(initial_points.size()));
-    }
+  ASSERT(initial_points.size() == function_blocks.size(),
+         "Size are different: Polynomial_Vector_Matrix: "
+           + std::to_string(function_blocks.size())
+           + ", initial points: " + std::to_string(initial_points.size()));
   Outer_Parameters parameters(parameters_in);
   const size_t rank(El::mpi::Rank()), num_procs(El::mpi::Size()),
     num_weights(normalization.size());
@@ -238,8 +236,7 @@ std::vector<El::BigFloat> compute_optimal(
                                         - block.Get(0, 1) * block.Get(0, 1);
                           break;
                         default:
-                          throw std::runtime_error(
-                            "too big: " + std::to_string(block.Height()));
+                          RUNTIME_ERROR("too big: ", block.Height());
                           break;
                         }
                       if(determinant < 1e-16)
@@ -279,9 +276,7 @@ std::vector<El::BigFloat> compute_optimal(
              || reason == SDP_Solver_Terminate_Reason::PrimalStepTooSmall
              || reason == SDP_Solver_Terminate_Reason::DualStepTooSmall)
             {
-              std::stringstream ss;
-              ss << "Can not find solution: " << reason;
-              throw std::runtime_error(ss.str());
+              RUNTIME_ERROR("Cannot find solution: ", reason);
             }
 
           El::Matrix<El::BigFloat> y(dual_objective_b_star.Height(), 1);

--- a/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser.hxx
+++ b/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser.hxx
@@ -2,6 +2,7 @@
 
 #include "sdpb_util/Number_State.hxx"
 #include "sdpb_util/Vector_State.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <El.hpp>
 #include <rapidjson/reader.h>
@@ -26,38 +27,35 @@ struct Checkpoint_Parser
         y_transform_state({"y_transform"s, ""s, ""s})
   {}
 
-  bool Null() { throw std::runtime_error("Null not allowed"); }
-  bool Bool(bool) { throw std::runtime_error("Bool not allowed"); }
+  bool Null() { RUNTIME_ERROR("Null not allowed"); }
+  bool Bool(bool) { RUNTIME_ERROR("Bool not allowed"); }
 
   bool Int(int)
   {
-    throw std::runtime_error(
-      "Int not allowed.  You must quote all numbers as strings.");
+    RUNTIME_ERROR("Int not allowed. You must quote all numbers as strings.");
   }
   bool Uint(unsigned)
   {
-    throw std::runtime_error(
-      "Uint not allowed.  You must quote all numbers as strings.");
+    RUNTIME_ERROR("Uint not allowed. You must quote all numbers as strings.");
   }
   bool Int64(int64_t)
   {
-    throw std::runtime_error(
-      "Int64 not allowed.  You must quote all numbers as strings.");
+    RUNTIME_ERROR("Int64 not allowed. You must quote all numbers as strings.");
   }
   bool Uint64(uint64_t)
   {
-    throw std::runtime_error(
-      "Uint64 not allowed.  You must quote all numbers as strings.");
+    RUNTIME_ERROR(
+      "Uint64 not allowed. You must quote all numbers as strings.");
   }
   bool Double(double)
   {
-    throw std::runtime_error(
-      "Double not allowed.  You must quote all numbers as strings.");
+    RUNTIME_ERROR(
+      "Double not allowed. You must quote all numbers as strings.");
   }
   bool RawNumber(const Ch *, rapidjson::SizeType, bool)
   {
-    throw std::runtime_error(
-      "Numbers not allowed.  You must quote all numbers as strings.");
+    RUNTIME_ERROR(
+      "Numbers not allowed. You must quote all numbers as strings.");
   }
   bool String(const Ch *str, rapidjson::SizeType length, bool copy);
   bool StartObject();

--- a/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser/EndArray.cxx
+++ b/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser/EndArray.cxx
@@ -1,4 +1,5 @@
 #include "../Checkpoint_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Checkpoint_Parser::EndArray(rapidjson::SizeType)
 {
@@ -6,21 +7,21 @@ bool Checkpoint_Parser::EndArray(rapidjson::SizeType)
     {
       if(parsing_generation)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected array ending inside  '"
-            + generation_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected array ending inside  '",
+            generation_state.name, "'");
         }
       else if(parsing_threshold)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected array ending inside  '"
-            + threshold_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected array ending inside  '",
+            threshold_state.name, "'");
         }
       else if(parsing_c_scale)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected array ending inside  '"
-            + c_scale_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected array ending inside  '",
+            c_scale_state.name, "'");
         }
       else if(parsing_yp)
         {
@@ -44,14 +45,14 @@ bool Checkpoint_Parser::EndArray(rapidjson::SizeType)
         }
       else
         {
-          throw std::runtime_error("Invalid input file.  Unexpected array "
-                                   "ending inside the main object.");
+          RUNTIME_ERROR("Invalid input file. "
+                        "Unexpected array ending inside the main object.");
         }
     }
   else
     {
-      throw std::runtime_error("Invalid input file.  Unexpected array ending "
-                               "outside of the main object.");
+      RUNTIME_ERROR("Invalid input file. "
+                    " Unexpected array ending outside of the main object.");
     }
   return true;
 }

--- a/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser/EndObject.cxx
+++ b/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser/EndObject.cxx
@@ -1,4 +1,5 @@
 #include "../Checkpoint_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Checkpoint_Parser::EndObject(rapidjson::SizeType)
 {
@@ -6,45 +7,45 @@ bool Checkpoint_Parser::EndObject(rapidjson::SizeType)
     {
       if(parsing_generation)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object ending inside '"
-            + generation_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected object ending inside '",
+            generation_state.name, "'");
         }
       else if(parsing_threshold)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object ending inside '"
-            + threshold_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected object ending inside '",
+            threshold_state.name, "'");
         }
       else if(parsing_c_scale)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object ending inside '"
-            + c_scale_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected object ending inside '",
+            c_scale_state.name, "'");
         }
       else if(parsing_yp)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object ending inside '"
-            + yp_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected object ending inside '",
+            yp_state.name, "'");
         }
       else if(parsing_b)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object ending inside '"
-            + b_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected object ending inside '",
+            b_state.name, "'");
         }
       else if(parsing_y_transform)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object ending inside '"
-            + y_transform_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected object ending inside '",
+            y_transform_state.name, "'");
         }
       else if(parsing_points)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object ending inside '"
-            + points_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected object ending inside '",
+            points_state.name, "'");
         }
       else
         {
@@ -53,8 +54,8 @@ bool Checkpoint_Parser::EndObject(rapidjson::SizeType)
     }
   else
     {
-      throw std::runtime_error("Invalid input file.  Unexpected object ending "
-                               "outside of the main object");
+      RUNTIME_ERROR("Invalid input file. "
+                    "Unexpected object ending outside of the main object");
     }
   return true;
 }

--- a/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser/Key.cxx
+++ b/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser/Key.cxx
@@ -1,4 +1,5 @@
 #include "../Checkpoint_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Checkpoint_Parser::Key(const Ch *str, rapidjson::SizeType length, bool)
 {
@@ -7,41 +8,39 @@ bool Checkpoint_Parser::Key(const Ch *str, rapidjson::SizeType length, bool)
     {
       if(parsing_generation)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '" + generation_state.name
-                                   + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key,
+                        "' inside '", generation_state.name, "'.");
         }
       else if(parsing_threshold)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '" + threshold_state.name
-                                   + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key,
+                        "' inside '", threshold_state.name, "'.");
         }
       else if(parsing_c_scale)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '" + c_scale_state.name + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key,
+                        "' inside '", c_scale_state.name , "'.");
         }
       else if(parsing_yp)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '" + yp_state.name + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '" , key
+                                   , "' inside '" , yp_state.name , "'.");
         }
       else if(parsing_b)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '" + b_state.name + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key
+                                   , "' inside '" , b_state.name , "'.");
         }
       else if(parsing_y_transform)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '" + y_transform_state.name
-                                   + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key
+                                   , "' inside '" , y_transform_state.name
+                                   , "'.");
         }
       else if(parsing_points)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '" + points_state.name + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key
+                                   , "' inside '" , points_state.name , "'.");
         }
 
       else if(key == generation_state.name)
@@ -74,13 +73,13 @@ bool Checkpoint_Parser::Key(const Ch *str, rapidjson::SizeType length, bool)
         }
       else
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
+          RUNTIME_ERROR("Invalid input file. Found the key '", key
                                    + "' inside the main object.");
         }
     }
   else
     {
-      throw std::runtime_error("Found a key outside of the main object: "
+      RUNTIME_ERROR("Found a key outside of the main object: "
                                + key);
     }
   return true;

--- a/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser/StartArray.cxx
+++ b/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser/StartArray.cxx
@@ -1,4 +1,5 @@
 #include "../Checkpoint_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Checkpoint_Parser::StartArray()
 {
@@ -6,21 +7,21 @@ bool Checkpoint_Parser::StartArray()
     {
       if(parsing_generation)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected array start inside  '"
-            + generation_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected array start inside  '",
+            generation_state.name, "'");
         }
       else if(parsing_threshold)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected array start inside  '"
-            + threshold_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected array start inside  '",
+            threshold_state.name, "'");
         }
       else if(parsing_c_scale)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected array start inside  '"
-            + c_scale_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected array start inside  '",
+            c_scale_state.name, "'");
         }
       else if(parsing_yp)
         {
@@ -40,13 +41,13 @@ bool Checkpoint_Parser::StartArray()
         }
       else
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unknown array inside the main object");
+          RUNTIME_ERROR(
+            "Invalid input file. Unknown array inside the main object");
         }
     }
   else
     {
-      throw std::runtime_error("Found an array outside of the SDP.");
+      RUNTIME_ERROR("Found an array outside of the SDP.");
     }
   return true;
 }

--- a/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser/StartObject.cxx
+++ b/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser/StartObject.cxx
@@ -1,4 +1,5 @@
 #include "../Checkpoint_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Checkpoint_Parser::StartObject()
 {
@@ -6,50 +7,43 @@ bool Checkpoint_Parser::StartObject()
     {
       if(parsing_generation)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object start inside '"
-            + generation_state.name + "'");
+          RUNTIME_ERROR("Invalid input file. Unexpected object start inside '",
+                        generation_state.name, "'");
         }
       else if(parsing_threshold)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object start inside '"
-            + threshold_state.name + "'");
+          RUNTIME_ERROR("Invalid input file. Unexpected object start inside '",
+                        threshold_state.name, "'");
         }
       else if(parsing_c_scale)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object start inside '"
-            + c_scale_state.name + "'");
+          RUNTIME_ERROR("Invalid input file. Unexpected object start inside '",
+                        c_scale_state.name, "'");
         }
       else if(parsing_yp)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object start inside '"
-            + yp_state.name + "'");
+          RUNTIME_ERROR("Invalid input file. Unexpected object start inside '",
+                        yp_state.name, "'");
         }
       else if(parsing_b)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object start inside '"
-            + b_state.name + "'");
+          RUNTIME_ERROR("Invalid input file. Unexpected object start inside '",
+                        b_state.name, "'");
         }
       else if(parsing_y_transform)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object start inside '"
-            + y_transform_state.name + "'");
+          RUNTIME_ERROR("Invalid input file. Unexpected object start inside '",
+                        y_transform_state.name, "'");
         }
       else if(parsing_points)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected object start inside '"
-            + points_state.name + "'");
+          RUNTIME_ERROR("Invalid input file. Unexpected object start inside '",
+                        points_state.name, "'");
         }
       else
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unknown object inside the main object");
+          RUNTIME_ERROR(
+            "Invalid input file. Unknown object inside the main object");
         }
     }
   else

--- a/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser/String.cxx
+++ b/src/outer_limits/compute_optimal/load_checkpoint/Checkpoint_Parser/String.cxx
@@ -1,4 +1,5 @@
 #include "../Checkpoint_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Checkpoint_Parser::String(const Ch *str, rapidjson::SizeType length, bool)
 {
@@ -38,15 +39,14 @@ bool Checkpoint_Parser::String(const Ch *str, rapidjson::SizeType length, bool)
         }
       else
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected string in the main object: '" + s
-            + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected string in the main object: '", s,
+            "'");
         }
     }
   else
     {
-      throw std::runtime_error("Found a string outside of the SDP: '" + s
-                               + "'");
+      RUNTIME_ERROR("Found a string outside of the SDP: '", s, "'");
     }
   return true;
 }

--- a/src/outer_limits/compute_optimal/load_checkpoint/load_checkpoint.cxx
+++ b/src/outer_limits/compute_optimal/load_checkpoint/load_checkpoint.cxx
@@ -67,15 +67,11 @@ void load_checkpoint(
           rapidjson::Reader reader;
           reader.Parse(wrapper, parser);
 
-          if(parser.generation_state.value != El::BigFloat(max_generation))
-            {
-              std::stringstream ss;
-              ss << "Invalid checkpoint.  The generation from the file name "
-                 << max_generation
-                 << " does not match the generation stored inside: "
-                 << parser.generation_state.value;
-              throw std::runtime_error(ss.str());
-            }
+          ASSERT(parser.generation_state.value == El::BigFloat(max_generation),
+                 "Invalid checkpoint. The generation from the file name ",
+                 max_generation,
+                 " does not match the generation stored inside: ",
+                 parser.generation_state.value);
 
           yp_to_y_star.Resize(parser.y_transform_state.value.size(),
                               parser.y_transform_state.value.size());

--- a/src/outer_limits/compute_optimal/save_checkpoint.cxx
+++ b/src/outer_limits/compute_optimal/save_checkpoint.cxx
@@ -1,4 +1,5 @@
 #include "sdpb_util/Verbosity.hxx"
+#include "sdpb_util/assert.hxx"
 #include "sdpb_util/ostream/ostream_vector.hxx"
 #include "sdpb_util/ostream/ostream_set.hxx"
 #include "sdpb_util/ostream/set_stream_precision.hxx"
@@ -43,9 +44,8 @@ void save_checkpoint(
         }
       else if(!is_directory(checkpoint_directory))
         {
-          throw std::runtime_error(
-            "Checkpoint directory '" + checkpoint_directory.string()
-            + "'already exists, but is not a directory");
+          RUNTIME_ERROR("Checkpoint directory ", checkpoint_directory,
+                        " already exists, but is not a directory");
         }
       if(backup_generation)
         {
@@ -168,10 +168,9 @@ void save_checkpoint(
                 }
               else
                 {
-                  std::stringstream ss;
-                  ss << "Error writing checkpoint file '"
-                     << checkpoint_filename << "'.  Exceeded max retries.\n";
-                  throw std::runtime_error(ss.str());
+                  RUNTIME_ERROR("Error writing checkpoint file ",
+                                checkpoint_filename,
+                                "'.  Exceeded max retries.");
                 }
             }
         }

--- a/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser.hxx
+++ b/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser.hxx
@@ -24,36 +24,36 @@ struct Function_Blocks_Parser
         functions_state({"functions"s, ""s, ""s, ""s, ""s})
   {}
 
-  bool Null() { throw std::runtime_error("Null not allowed"); }
-  bool Bool(bool) { throw std::runtime_error("Bool not allowed"); }
+  bool Null() { RUNTIME_ERROR("Null not allowed"); }
+  bool Bool(bool) { RUNTIME_ERROR("Bool not allowed"); }
   bool Int(int)
   {
-    throw std::runtime_error(
+    RUNTIME_ERROR(
       "Int not allowed.  You must quote all numbers as strings.");
   }
   bool Uint(unsigned)
   {
-    throw std::runtime_error(
+    RUNTIME_ERROR(
       "Uint not allowed.  You must quote all numbers as strings.");
   }
   bool Int64(int64_t)
   {
-    throw std::runtime_error(
+    RUNTIME_ERROR(
       "Int64 not allowed.  You must quote all numbers as strings.");
   }
   bool Uint64(uint64_t)
   {
-    throw std::runtime_error(
+    RUNTIME_ERROR(
       "Uint64 not allowed.  You must quote all numbers as strings.");
   }
   bool Double(double)
   {
-    throw std::runtime_error(
+    RUNTIME_ERROR(
       "Double not allowed.  You must quote all numbers as strings.");
   }
   bool RawNumber(const Ch *, rapidjson::SizeType, bool)
   {
-    throw std::runtime_error(
+    RUNTIME_ERROR(
       "Numbers not allowed.  You must quote all numbers as strings.");
   }
   bool String(const Ch *str, rapidjson::SizeType length, bool copy);

--- a/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser/EndArray.cxx
+++ b/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser/EndArray.cxx
@@ -1,4 +1,5 @@
 #include "../Function_Blocks_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Function_Blocks_Parser::EndArray(rapidjson::SizeType)
 {
@@ -21,14 +22,14 @@ bool Function_Blocks_Parser::EndArray(rapidjson::SizeType)
         }
       else
         {
-          throw std::runtime_error(
-            "Invalid input file.  Ending an array inside the main object.");
+          RUNTIME_ERROR(
+            "Invalid input file. Ending an array inside the main object.");
         }
     }
   else
     {
-      throw std::runtime_error(
-        "Invalid input file.  Ending an array outside of the main object.");
+      RUNTIME_ERROR(
+        "Invalid input file. Ending an array outside of the main object.");
     }
   return true;
 }

--- a/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser/EndObject.cxx
+++ b/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser/EndObject.cxx
@@ -1,4 +1,5 @@
 #include "../Function_Blocks_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Function_Blocks_Parser::EndObject(rapidjson::SizeType)
 {
@@ -6,20 +7,18 @@ bool Function_Blocks_Parser::EndObject(rapidjson::SizeType)
     {
       if(parsing_objective)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Found an object end inside '"
-            + objective_state.name + "'");
+          RUNTIME_ERROR("Invalid input file. Found an object end inside '",
+                        objective_state.name, "'");
         }
       else if(parsing_normalization)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Found an object end inside '"
-            + normalization_state.name + "'");
+          RUNTIME_ERROR("Invalid input file. Found an object end inside '",
+                        normalization_state.name, "'");
         }
       else if(parsing_functions)
         {
           functions_state.json_end_object();
-          parsing_functions=functions_state.inside;
+          parsing_functions = functions_state.inside;
         }
       else
         {
@@ -28,8 +27,7 @@ bool Function_Blocks_Parser::EndObject(rapidjson::SizeType)
     }
   else
     {
-      throw std::runtime_error(
-        "Invalid input file.  Ending an object outside of the SDP");
+      RUNTIME_ERROR("Invalid input file. Ending an object outside of the SDP");
     }
   return true;
 }

--- a/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser/Key.cxx
+++ b/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser/Key.cxx
@@ -1,22 +1,21 @@
 #include "../Function_Blocks_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Function_Blocks_Parser::Key(const Ch *str, rapidjson::SizeType length,
                                  bool)
 {
-  std::string key(str, length);
+  const std::string key(str, length);
   if(inside)
     {
       if(parsing_objective)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '" + objective_state.name
-                                   + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key,
+                        "' inside '", objective_state.name, "'.");
         }
       else if(parsing_normalization)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '" + normalization_state.name
-                                   + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key,
+                        "' inside '", normalization_state.name, "'.");
         }
       else if(parsing_functions)
         {
@@ -36,14 +35,13 @@ bool Function_Blocks_Parser::Key(const Ch *str, rapidjson::SizeType length,
         }
       else
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside the main object.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key,
+                        "' inside the main object.");
         }
     }
   else
     {
-      throw std::runtime_error("Found a key outside of the main object: "
-                               + key);
+      RUNTIME_ERROR("Found a key outside of the main object: ", key);
     }
   return true;
 }

--- a/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser/StartArray.cxx
+++ b/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser/StartArray.cxx
@@ -1,4 +1,5 @@
 #include "../Function_Blocks_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Function_Blocks_Parser::StartArray()
 {
@@ -18,13 +19,13 @@ bool Function_Blocks_Parser::StartArray()
         }
       else
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unknown array inside the main object");
+          RUNTIME_ERROR(
+            "Invalid input file. Unknown array inside the main object");
         }
     }
   else
     {
-      throw std::runtime_error("Found an array outside of the SDP.");
+      RUNTIME_ERROR("Found an array outside of the SDP.");
     }
   return true;
 }

--- a/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser/StartObject.cxx
+++ b/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser/StartObject.cxx
@@ -1,4 +1,5 @@
 #include "../Function_Blocks_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Function_Blocks_Parser::StartObject()
 {
@@ -6,15 +7,15 @@ bool Function_Blocks_Parser::StartObject()
     {
       if(parsing_objective)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Found an object inside '"
-            + objective_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Found an object inside '"
+            , objective_state.name , "'");
         }
       else if(parsing_normalization)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Found an object inside '"
-            + normalization_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Found an object inside '"
+            , normalization_state.name , "'");
         }
       else if(parsing_functions)
         {
@@ -22,8 +23,8 @@ bool Function_Blocks_Parser::StartObject()
         }
       else
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unknown object inside the main object");
+          RUNTIME_ERROR(
+            "Invalid input file. Unknown object inside the main object");
         }
     }
   else

--- a/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser/String.cxx
+++ b/src/outer_limits/read_function_blocks/read_json/Function_Blocks_Parser/String.cxx
@@ -1,4 +1,5 @@
 #include "../Function_Blocks_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Function_Blocks_Parser::String(const Ch *str, rapidjson::SizeType length,
                                     bool)
@@ -20,15 +21,14 @@ bool Function_Blocks_Parser::String(const Ch *str, rapidjson::SizeType length,
         }
       else
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected string in the main object: '" + s
-            + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected string in the main object: '" , s
+            , "'");
         }
     }
   else
     {
-      throw std::runtime_error("Found a string outside of the SDP: '" + s
-                               + "'");
+      RUNTIME_ERROR("Found a string outside of the SDP: '" , s , "'");
     }
   return true;
 }

--- a/src/outer_limits/read_function_blocks/read_json/Function_State/json_end_array.cxx
+++ b/src/outer_limits/read_function_blocks/read_json/Function_State/json_end_array.cxx
@@ -1,24 +1,22 @@
 #include "../Function_State.hxx"
+#include "sdpb_util/assert.hxx"
 
 void Function_State::json_end_array()
 {
   if(parsing_max_delta)
     {
-      throw std::runtime_error(
-        "Invalid input file.  Unexpected array end inside '" + name + "."
-        + max_delta_state.name + "'.");
+      RUNTIME_ERROR("Invalid input file. Unexpected array end inside '", name,
+                    ".", max_delta_state.name, "'.");
     }
   else if(parsing_epsilon_value)
     {
-      throw std::runtime_error(
-        "Invalid input file.  Unexpected array end inside '" + name + "."
-        + epsilon_value_state.name + "'.");
+      RUNTIME_ERROR("Invalid input file. Unexpected array end inside '", name,
+                    ".", epsilon_value_state.name, "'.");
     }
   else if(parsing_infinity_value)
     {
-      throw std::runtime_error(
-        "Invalid input file.  Unexpected array end inside '" + name + "."
-        + infinity_value_state.name + "'.");
+      RUNTIME_ERROR("Invalid input file. Unexpected array end inside '", name,
+                    ".", infinity_value_state.name, "'.");
     }
   else if(parsing_chebyshev_values)
     {
@@ -27,7 +25,7 @@ void Function_State::json_end_array()
     }
   else
     {
-      throw std::runtime_error(
-        "Invalid input file.  Unexpected array end inside '" + name + "'");
+      RUNTIME_ERROR("Invalid input file. Unexpected array end inside '", name,
+                    "'");
     }
 }

--- a/src/outer_limits/read_function_blocks/read_json/Function_State/json_end_object.cxx
+++ b/src/outer_limits/read_function_blocks/read_json/Function_State/json_end_object.cxx
@@ -1,5 +1,6 @@
 #include "../Function_State.hxx"
 #include "sdpb_util/Boost_Float.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <boost/math/constants/constants.hpp>
 
@@ -7,27 +8,27 @@ void Function_State::json_end_object()
 {
   if(parsing_max_delta)
     {
-      throw std::runtime_error(
-        "Invalid input file.  Unexpected object end inside '" + name + "."
-        + max_delta_state.name + "'.");
+      RUNTIME_ERROR(
+        "Invalid input file. Unexpected object end inside '" , name , "."
+        + max_delta_state.name , "'.");
     }
   else if(parsing_epsilon_value)
     {
-      throw std::runtime_error(
-        "Invalid input file.  Unexpected object end inside '" + name + "."
-        + epsilon_value_state.name + "'.");
+      RUNTIME_ERROR(
+        "Invalid input file. Unexpected object end inside '" , name , "."
+        + epsilon_value_state.name , "'.");
     }
   else if(parsing_infinity_value)
     {
-      throw std::runtime_error(
-        "Invalid input file.  Unexpected object end inside '" + name + "."
-        + infinity_value_state.name + "'.");
+      RUNTIME_ERROR(
+        "Invalid input file. Unexpected object end inside '" , name , "."
+        + infinity_value_state.name , "'.");
     }
   else if(parsing_chebyshev_values)
     {
-      throw std::runtime_error(
-        "Invalid input file.  Unexpected object end inside '" + name + "."
-        + chebyshev_values_state.name + "'.");
+      RUNTIME_ERROR(
+        "Invalid input file. Unexpected object end inside '" , name , "."
+        + chebyshev_values_state.name , "'.");
     }
 
   // Convert from sampled values to chebyshev coefficients.

--- a/src/outer_limits/read_function_blocks/read_json/Function_State/json_key.cxx
+++ b/src/outer_limits/read_function_blocks/read_json/Function_State/json_key.cxx
@@ -4,27 +4,23 @@ void Function_State::json_key(const std::string &key)
 {
   if(parsing_max_delta)
     {
-      throw std::runtime_error("Invalid input file.  Unexpected key '" + key
-                               + "' inside '" + name + "."
-                               + max_delta_state.name + "'.");
+      RUNTIME_ERROR("Invalid input file. Unexpected key '", key, "' inside '",
+                    name, "." + max_delta_state.name, "'.");
     }
   else if(parsing_epsilon_value)
     {
-      throw std::runtime_error("Invalid input file.  Unexpected key '" + key
-                               + "' inside '" + name + "."
-                               + epsilon_value_state.name + "'.");
+      RUNTIME_ERROR("Invalid input file. Unexpected key '", key, "' inside '",
+                    name, "." + epsilon_value_state.name, "'.");
     }
   else if(parsing_infinity_value)
     {
-      throw std::runtime_error("Invalid input file.  Unexpected key '" + key
-                               + "' inside '" + name + "."
-                               + infinity_value_state.name + "'.");
+      RUNTIME_ERROR("Invalid input file. Unexpected key '", key, "' inside '",
+                    name, "." + infinity_value_state.name, "'.");
     }
   else if(parsing_chebyshev_values)
     {
-      throw std::runtime_error("Invalid input file.  Unexpected key '" + key
-                               + "' inside '" + name + "."
-                               + chebyshev_values_state.name + "'.");
+      RUNTIME_ERROR("Invalid input file. Unexpected key '", key, "' inside '",
+                    name, "." + chebyshev_values_state.name, "'.");
     }
   else if(key == max_delta_state.name)
     {
@@ -44,7 +40,7 @@ void Function_State::json_key(const std::string &key)
     }
   else
     {
-      throw std::runtime_error("Invalid input file.  Unexpected key '" + key
-                               + "' inside '" + name + "'");
+      RUNTIME_ERROR("Invalid input file. Unexpected key '", key, "' inside '",
+                    name, "'");
     }
 }

--- a/src/outer_limits/read_function_blocks/read_json/Function_State/json_start_array.cxx
+++ b/src/outer_limits/read_function_blocks/read_json/Function_State/json_start_array.cxx
@@ -4,19 +4,19 @@ void Function_State::json_start_array()
 {
   if(parsing_max_delta)
     {
-      throw std::runtime_error("Invalid input file.  Unexpected array inside '"
-                               + name + "." + max_delta_state.name + "'.");
+      RUNTIME_ERROR("Invalid input file. Unexpected array inside '"
+                               + name , "." , max_delta_state.name , "'.");
     }
   else if(parsing_epsilon_value)
     {
-      throw std::runtime_error("Invalid input file.  Unexpected array inside '"
-                               + name + "." + epsilon_value_state.name + "'.");
+      RUNTIME_ERROR("Invalid input file. Unexpected array inside '"
+                               + name , "." , epsilon_value_state.name , "'.");
     }
   else if(parsing_infinity_value)
     {
-      throw std::runtime_error("Invalid input file.  Unexpected array inside '"
-                               + name + "." + infinity_value_state.name
-                               + "'.");
+      RUNTIME_ERROR("Invalid input file. Unexpected array inside '"
+                               + name , "." , infinity_value_state.name
+                               , "'.");
     }
   else if(parsing_chebyshev_values)
     {
@@ -24,7 +24,7 @@ void Function_State::json_start_array()
     }
   else
     {
-      throw std::runtime_error("Invalid input file.  Unexpected array inside '"
-                               + name + "'");
+      RUNTIME_ERROR("Invalid input file. Unexpected array inside '"
+                               + name , "'");
     }
 }

--- a/src/outer_limits/read_function_blocks/read_json/Function_State/json_start_object.cxx
+++ b/src/outer_limits/read_function_blocks/read_json/Function_State/json_start_object.cxx
@@ -4,8 +4,8 @@ void Function_State::json_start_object()
 {
   if(inside)
     {
-      throw std::runtime_error("Invalid input file.  Found an object inside '"
-                               + name + "'.");
+      RUNTIME_ERROR("Invalid input file. Found an object inside '"
+                               + name , "'.");
     }
   else
     {

--- a/src/outer_limits/read_function_blocks/read_json/Function_State/json_string.cxx
+++ b/src/outer_limits/read_function_blocks/read_json/Function_State/json_string.cxx
@@ -27,7 +27,7 @@ void Function_State::json_string(const std::string &s)
     }
   else
     {
-      throw std::runtime_error("Invalid input file.  Unexpected string '" + s
-                               + "' inside '" + name + "'");
+      RUNTIME_ERROR("Invalid input file. Unexpected string '" , s
+                               , "' inside '" , name , "'");
     }
 }

--- a/src/outer_limits/read_points/read_points.cxx
+++ b/src/outer_limits/read_points/read_points.cxx
@@ -23,7 +23,6 @@ void read_points(const fs::path &input_path,
     }
   else
     {
-      throw std::runtime_error("Unknown extension for file: "
-                               + input_path.string());
+      RUNTIME_ERROR("Unknown extension for file: ", input_path);
     }
 }

--- a/src/outer_limits/read_points/read_points_json/Points_Parser.hxx
+++ b/src/outer_limits/read_points/read_points_json/Points_Parser.hxx
@@ -17,36 +17,36 @@ struct Points_Parser
       : points_state({"points"s, ""s, ""s})
   {}
 
-  bool Null() { throw std::runtime_error("Null not allowed"); }
-  bool Bool(bool) { throw std::runtime_error("Bool not allowed"); }
+  bool Null() { RUNTIME_ERROR("Null not allowed"); }
+  bool Bool(bool) { RUNTIME_ERROR("Bool not allowed"); }
   bool Int(int)
   {
-    throw std::runtime_error(
+    RUNTIME_ERROR(
       "Int not allowed.  You must quote all numbers as strings.");
   }
   bool Uint(unsigned)
   {
-    throw std::runtime_error(
+    RUNTIME_ERROR(
       "Uint not allowed.  You must quote all numbers as strings.");
   }
   bool Int64(int64_t)
   {
-    throw std::runtime_error(
+    RUNTIME_ERROR(
       "Int64 not allowed.  You must quote all numbers as strings.");
   }
   bool Uint64(uint64_t)
   {
-    throw std::runtime_error(
+    RUNTIME_ERROR(
       "Uint64 not allowed.  You must quote all numbers as strings.");
   }
   bool Double(double)
   {
-    throw std::runtime_error(
+    RUNTIME_ERROR(
       "Double not allowed.  You must quote all numbers as strings.");
   }
   bool RawNumber(const Ch *, rapidjson::SizeType, bool)
   {
-    throw std::runtime_error(
+    RUNTIME_ERROR(
       "Numbers not allowed.  You must quote all numbers as strings.");
   }
   bool String(const Ch *str, rapidjson::SizeType length, bool copy);

--- a/src/outer_limits/read_points/read_points_json/Points_Parser/EndArray.cxx
+++ b/src/outer_limits/read_points/read_points_json/Points_Parser/EndArray.cxx
@@ -1,4 +1,5 @@
 #include "../Points_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Points_Parser::EndArray(rapidjson::SizeType)
 {
@@ -11,14 +12,14 @@ bool Points_Parser::EndArray(rapidjson::SizeType)
         }
       else
         {
-          throw std::runtime_error(
-            "Invalid input file.  Ending an array inside the main object.");
+          RUNTIME_ERROR(
+            "Invalid input file. Ending an array inside the main object.");
         }
     }
   else
     {
-      throw std::runtime_error(
-        "Invalid input file.  Ending an array outside of the main object.");
+      RUNTIME_ERROR(
+        "Invalid input file. Ending an array outside of the main object.");
     }
   return true;
 }

--- a/src/outer_limits/read_points/read_points_json/Points_Parser/EndObject.cxx
+++ b/src/outer_limits/read_points/read_points_json/Points_Parser/EndObject.cxx
@@ -6,9 +6,9 @@ bool Points_Parser::EndObject(rapidjson::SizeType)
     {
       if(parsing_points)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Found an object end inside '"
-            + points_state.name + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Found an object end inside '"
+            + points_state.name , "'");
         }
       else
         {
@@ -17,8 +17,8 @@ bool Points_Parser::EndObject(rapidjson::SizeType)
     }
   else
     {
-      throw std::runtime_error(
-        "Invalid input file.  Ending an object outside of the SDP");
+      RUNTIME_ERROR(
+        "Invalid input file. Ending an object outside of the SDP");
     }
   return true;
 }

--- a/src/outer_limits/read_points/read_points_json/Points_Parser/Key.cxx
+++ b/src/outer_limits/read_points/read_points_json/Points_Parser/Key.cxx
@@ -7,8 +7,8 @@ bool Points_Parser::Key(const Ch *str, rapidjson::SizeType length, bool)
     {
       if(parsing_points)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '" + points_state.name + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key
+                                   , "' inside '", points_state.name , "'.");
         }
       else if(key == points_state.name)
         {
@@ -16,13 +16,13 @@ bool Points_Parser::Key(const Ch *str, rapidjson::SizeType length, bool)
         }
       else
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside the main object.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key
+                                   , "' inside the main object.");
         }
     }
   else
     {
-      throw std::runtime_error("Found a key outside of the main object: "
+      RUNTIME_ERROR("Found a key outside of the main object: "
                                + key);
     }
   return true;

--- a/src/outer_limits/read_points/read_points_json/Points_Parser/StartArray.cxx
+++ b/src/outer_limits/read_points/read_points_json/Points_Parser/StartArray.cxx
@@ -10,13 +10,13 @@ bool Points_Parser::StartArray()
         }
       else
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unknown array inside the main object");
+          RUNTIME_ERROR(
+            "Invalid input file. Unknown array inside the main object");
         }
     }
   else
     {
-      throw std::runtime_error("Found an array outside of the SDP.");
+      RUNTIME_ERROR("Found an array outside of the SDP.");
     }
   return true;
 }

--- a/src/outer_limits/read_points/read_points_json/Points_Parser/StartObject.cxx
+++ b/src/outer_limits/read_points/read_points_json/Points_Parser/StartObject.cxx
@@ -6,14 +6,14 @@ bool Points_Parser::StartObject()
     {
       if(parsing_points)
         {
-          throw std::runtime_error(
-            "Invalid input file.  Found an object inside '" + points_state.name
-            + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Found an object inside '", points_state.name
+            , "'");
         }
       else
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unknown object inside the main object");
+          RUNTIME_ERROR(
+            "Invalid input file. Unknown object inside the main object");
         }
     }
   else

--- a/src/outer_limits/read_points/read_points_json/Points_Parser/String.cxx
+++ b/src/outer_limits/read_points/read_points_json/Points_Parser/String.cxx
@@ -11,15 +11,15 @@ bool Points_Parser::String(const Ch *str, rapidjson::SizeType length, bool)
         }
       else
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected string in the main object: '" + s
-            + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected string in the main object: '", s
+            , "'");
         }
     }
   else
     {
-      throw std::runtime_error("Found a string outside of the SDP: '" + s
-                               + "'");
+      RUNTIME_ERROR("Found a string outside of the SDP: '", s
+                               , "'");
     }
   return true;
 }

--- a/src/pmp/Polynomial_Matrix_Program.hxx
+++ b/src/pmp/Polynomial_Matrix_Program.hxx
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Polynomial_Vector_Matrix.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <El.hpp>
 
@@ -39,36 +40,24 @@ struct Polynomial_Matrix_Program
         matrix_index_local_to_global(std::move(matrix_index_local_to_global))
   {
     // Validate
-    if(this->num_matrices == 0)
-      El::RuntimeError("Polynomial_Matrix_Program is empty!");
-    if(this->objective.empty())
-      El::RuntimeError("objective is empty!");
-    if(this->objective.size() != this->normalization.size())
-      {
-        El::RuntimeError("objective.size=", this->objective.size(),
-                         "should be equal to normalization.size=",
-                         this->normalization.size());
-      }
-    if(this->matrices.size() > num_matrices)
-      {
-        El::RuntimeError("matrices.size=", this->matrices.size(),
-                         " should not exceed", num_matrices);
-      }
-    if(this->matrices.size() != this->matrix_index_local_to_global.size())
-      {
-        El::RuntimeError(
-          "matrices.size=", this->matrices.size(),
-          " should be equal to matrix_index_local_to_global.size",
-          this->matrix_index_local_to_global.size());
-      }
+    ASSERT(this->num_matrices != 0);
+    ASSERT(!this->objective.empty());
+    ASSERT(
+      this->objective.size() == this->normalization.size(),
+      "objective.size=", this->objective.size(),
+      "should be equal to normalization.size=", this->normalization.size());
+    ASSERT(this->matrices.size() <= num_matrices,
+           "matrices.size=", this->matrices.size(), " should not exceed",
+           num_matrices);
+    ASSERT(this->matrices.size() == this->matrix_index_local_to_global.size(),
+           "matrices.size=", this->matrices.size(),
+           " should be equal to matrix_index_local_to_global.size",
+           this->matrix_index_local_to_global.size());
+
     for(const size_t global_index : this->matrix_index_local_to_global)
       {
-        if(global_index >= num_matrices)
-          {
-            El::RuntimeError(
-              "Block index=", global_index,
-              " should be less than num_matrices=", num_matrices);
-          }
+        ASSERT(global_index < num_matrices, "Block index=", global_index,
+               " should be less than num_matrices=", num_matrices);
       }
     // TODO: we should also check that matrix indices from all ranks
     // are unique and cover [0, num_matrices) range.

--- a/src/pmp/Polynomial_Vector_Matrix.cxx
+++ b/src/pmp/Polynomial_Vector_Matrix.cxx
@@ -1,6 +1,7 @@
 #include "Polynomial_Vector_Matrix.hxx"
 
 #include "sdpb_util/Boost_Float.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <boost/math/constants/constants.hpp>
 
@@ -11,7 +12,7 @@ sample_scalings(const std::vector<Boost_Float> &points,
                 const Damped_Rational &damped_rational);
 
 Polynomial_Vector bilinear_basis(const Damped_Rational &damped_rational,
-                                       const size_t &half_max_degree);
+                                 const size_t &half_max_degree);
 
 namespace
 {
@@ -132,25 +133,18 @@ Polynomial_Vector_Matrix::Polynomial_Vector_Matrix(
 
 void Polynomial_Vector_Matrix::validate(const int64_t max_degree) const
 {
-  if(sample_points.size() != max_degree + 1)
-    {
-      El::RuntimeError("sample_points.size()=", sample_points.size(),
-                       ", expected ", max_degree + 1);
-    }
-  if(sample_scalings.size() != sample_points.size())
-    {
-      El::RuntimeError("sample_scalings.size()=", sample_scalings.size(),
-                       ", expected ", sample_points.size());
-    }
-  if(bilinear_basis.size() != max_degree / 2 + 1)
-    {
-      El::RuntimeError("bilinear_basis.size()=", bilinear_basis.size(),
-                       ", expected ", max_degree / 2 + 1);
-    }
+  ASSERT(sample_points.size() == max_degree + 1,
+         "sample_points.size()=", sample_points.size(), ", expected ",
+         max_degree + 1);
+  ASSERT(sample_scalings.size() == sample_points.size(),
+         "sample_scalings.size()=", sample_scalings.size(), ", expected ",
+         sample_points.size());
+  ASSERT(bilinear_basis.size() == max_degree / 2 + 1,
+         "bilinear_basis.size()=", bilinear_basis.size(), ", expected ",
+         max_degree / 2 + 1);
 
-  if(polynomials.Height() != polynomials.Width())
-    El::RuntimeError("Polynomial Matrix should be square! Height()=",
-                     polynomials.Height(), ", Width()=", polynomials.Width());
+  ASSERT(polynomials.Height() == polynomials.Width(),
+         "Height()=", polynomials.Height(), " Width()=", polynomials.Width());
 
   // TODO check if this is fast enough
   for(int i = 0; i < polynomials.Height(); ++i)
@@ -158,8 +152,6 @@ void Polynomial_Vector_Matrix::validate(const int64_t max_degree) const
       {
         if(i == j)
           continue;
-        if(polynomials(i, j) != polynomials(j, i))
-          El::RuntimeError(
-            "Polynomial vector matrix is not symmetric at i=", i, " j=", j);
+        ASSERT(polynomials(i, j) == polynomials(j, i), "i=", i, " j=", j);
       }
 }

--- a/src/pmp2sdp/Archive_Writer/Archive_Writer.cxx
+++ b/src/pmp2sdp/Archive_Writer/Archive_Writer.cxx
@@ -1,5 +1,7 @@
 #include "../Archive_Writer.hxx"
 
+#include "sdpb_util/assert.hxx"
+
 #include <stdexcept>
 
 Archive_Writer::Archive_Writer(const std::filesystem::path &filename)
@@ -12,7 +14,6 @@ Archive_Writer::Archive_Writer(const std::filesystem::path &filename)
           != ARCHIVE_OK
      || archive_write_open_filename(ptr.get(), filename.c_str()) != ARCHIVE_OK)
     {
-      throw std::runtime_error(
-        "Unable to set options for writing an archive.");
+      RUNTIME_ERROR("Unable to set options for writing an archive.");
     }
 }

--- a/src/pmp2sdp/Archive_Writer/write_entry.cxx
+++ b/src/pmp2sdp/Archive_Writer/write_entry.cxx
@@ -1,4 +1,5 @@
 #include "../Archive_Writer.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <stdexcept>
 
@@ -9,7 +10,7 @@ void Archive_Writer::write_entry(const Archive_Entry &entry,
 {
   if(archive_write_header(ptr.get(), entry.entry_ptr.get()) != ARCHIVE_OK)
     {
-      throw std::runtime_error("Error when writing archive header");
+      RUNTIME_ERROR("Error when writing archive header");
     }
   std::array<char, 8192> buffer;
   stream.read(buffer.data(), buffer.size());
@@ -17,12 +18,12 @@ void Archive_Writer::write_entry(const Archive_Entry &entry,
     {
       if(archive_write_data(ptr.get(), buffer.data(), buffer.size()) < 0)
         {
-          throw std::runtime_error("Error when writing archive data");
+          RUNTIME_ERROR("Error when writing archive data");
         }
       stream.read(buffer.data(), buffer.size());
     }
   if(archive_write_data(ptr.get(), buffer.data(), stream.gcount()) < 0)
     {
-      throw std::runtime_error("Error when writing archive final data");
+      RUNTIME_ERROR("Error when writing archive final data");
     }
 }

--- a/src/pmp2sdp/Block_File_Format.hxx
+++ b/src/pmp2sdp/Block_File_Format.hxx
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "sdpb_util/assert.hxx"
+
 #include <iostream>
 #include <string>
 
@@ -30,6 +32,6 @@ operator<<(std::ostream &out, const Block_File_Format &format)
   else if(format == json)
     out << "json";
   else
-    throw std::out_of_range("Block_File_Format=" + std::to_string(format));
+    THROW(std::out_of_range, "Block_File_Format=", std::to_string(format));
   return out;
 }

--- a/src/pmp2sdp/Output_SDP/Output_SDP.cxx
+++ b/src/pmp2sdp/Output_SDP/Output_SDP.cxx
@@ -57,17 +57,17 @@ namespace
 
   void validate(const Output_SDP &sdp)
   {
-    if(sdp.num_blocks == 0)
-      El::RuntimeError("sdp.num_blocks == 0");
-    if(sdp.dual_constraint_groups.size() > sdp.num_blocks)
-      El::RuntimeError("sdp.dual_constraint_groups.size()=",
-                       sdp.dual_constraint_groups.size(),
-                       " should not exceed sdp.num_blocks=", sdp.num_blocks);
+    ASSERT(sdp.num_blocks > 0);
+    ASSERT(
+      sdp.dual_constraint_groups.size() <= sdp.num_blocks,
+      "sdp.dual_constraint_groups.size()=", sdp.dual_constraint_groups.size(),
+      " should not exceed sdp.num_blocks=", sdp.num_blocks);
     for(const auto &group : sdp.dual_constraint_groups)
-      if(group.block_index >= sdp.num_blocks)
-        El::RuntimeError(
-          "group.block_index=", group.block_index,
-          " should be less than sdp.num_blocks=", sdp.num_blocks);
+      {
+        ASSERT(group.block_index < sdp.num_blocks,
+               "group.block_index=", group.block_index,
+               " should be less than sdp.num_blocks=", sdp.num_blocks);
+      }
     // TODO: we should also check that block indices from all ranks
     // are unique and cover [0, num_blocks) range.
     // This is checked indirectly in write_sdp().

--- a/src/pmp2sdp/byte_counter.hxx
+++ b/src/pmp2sdp/byte_counter.hxx
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include "sdpb_util/assert.hxx"
+
 #include <algorithm>
 #include <boost/iostreams/categories.hpp>
 #include <boost/iostreams/char_traits.hpp>
@@ -40,8 +42,7 @@ public:
   template <typename Source>
   std::streamsize read(Source &, char_type *, std::streamsize)
   {
-    throw std::runtime_error(
-      "INTERNAL_ERROR: byte_counter::read() not implemented");
+    LOGIC_ERROR("INTERNAL_ERROR: byte_counter::read() not implemented");
   }
 
   std::streamsize num_bytes;

--- a/src/pmp2sdp/write_block_data.cxx
+++ b/src/pmp2sdp/write_block_data.cxx
@@ -2,6 +2,7 @@
 #include "write_vector.hxx"
 #include "sdpb_util/ostream/set_stream_precision.hxx"
 #include "Block_File_Format.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <boost/serialization/vector.hpp>
 #include <boost/archive/binary_oarchive.hpp>
@@ -108,6 +109,6 @@ void write_block_data(std::ostream &os, const Dual_Constraint_Group &group,
     {
     case bin: write_block_data_bin(os, group); break;
     case json: write_block_data_json(os, group); break;
-    default: El::RuntimeError("Unknown Block_File_Format: ", format);
+    default: RUNTIME_ERROR("Unknown Block_File_Format: ", format);
     }
 }

--- a/src/pmp_read/PMP_File_Parse_Result.cxx
+++ b/src/pmp_read/PMP_File_Parse_Result.cxx
@@ -1,10 +1,12 @@
 #include "PMP_File_Parse_Result.hxx"
 
+#include "sdpb_util/assert.hxx"
+
 namespace fs = std::filesystem;
 
-PMP_File_Parse_Result read_json(
-  const std::filesystem::path &input_path,
-  const std::function<bool(size_t matrix_index)> &should_parse_matrix);
+PMP_File_Parse_Result
+read_json(const std::filesystem::path &input_path,
+          const std::function<bool(size_t matrix_index)> &should_parse_matrix);
 
 PMP_File_Parse_Result read_mathematica(
   const std::filesystem::path &input_path,
@@ -37,7 +39,7 @@ PMP_File_Parse_Result PMP_File_Parse_Result::read(
         }
       else
         {
-          El::RuntimeError("Expected .json, .m, or .xml extension.");
+          RUNTIME_ERROR("Expected .json, .m, or .xml extension.");
         }
 
       // Validate
@@ -46,24 +48,23 @@ PMP_File_Parse_Result PMP_File_Parse_Result::read(
     }
   catch(std::exception &e)
     {
-      El::RuntimeError("Error when parsing ", input_path, ": ", e.what());
+      RUNTIME_ERROR("Error when parsing ", input_path, ": ", e.what());
     }
   return result;
 }
 void PMP_File_Parse_Result::validate(const PMP_File_Parse_Result &result)
 {
-  if(result.parsed_matrices.size() > result.num_matrices)
-    El::LogicError("parsed_matrices.size()=", result.parsed_matrices.size(),
-                   " should not exceed num_matrices=", result.num_matrices);
+  ASSERT(result.parsed_matrices.size() <= result.num_matrices,
+         "parsed_matrices.size()=", result.parsed_matrices.size(),
+         " should not exceed num_matrices=", result.num_matrices);
 
   for(auto &[index, matrix] : result.parsed_matrices)
     {
-      if(index >= result.num_matrices)
-        El::LogicError("index=", index, "should be less than",
-                       result.num_matrices);
+      ASSERT(index < result.num_matrices, "index=", index,
+             "should be less than", result.num_matrices);
     }
 
   if(result.num_matrices == 0 && result.objective.empty()
      && result.normalization.empty())
-    El::RuntimeError("Nothing was read from input file.");
+    RUNTIME_ERROR("Nothing was read from input file.");
 }

--- a/src/pmp_read/read_json/Json_Damped_Rational_Parser.hxx
+++ b/src/pmp_read/read_json/Json_Damped_Rational_Parser.hxx
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "pmp/Damped_Rational.hxx"
+#include "sdpb_util/assert.hxx"
 #include "sdpb_util/json/Abstract_Json_Object_Parser.hxx"
 #include "sdpb_util/json/Json_Float_Parser.hxx"
 
@@ -55,7 +56,7 @@ protected:
       return constant_parser;
     if(key == "poles")
       return poles_parser;
-    El::RuntimeError("Json_Damped_Rational_Parser: unknown key=", key);
+    RUNTIME_ERROR("Json_Damped_Rational_Parser: unknown key=", key);
   }
 
 public:

--- a/src/pmp_read/read_json/Json_PMP_Parser.cxx
+++ b/src/pmp_read/read_json/Json_PMP_Parser.cxx
@@ -11,7 +11,7 @@ Json_PMP_Parser::Json_PMP_Parser(
         [this](std::vector<El::BigFloat> &&result) {
           this->result.objective = std::move(result);
         },
-        [] { El::LogicError(R"(Skipping "objective" not allowed)"); }),
+        [] { LOGIC_ERROR(R"(Skipping "objective" not allowed)"); }),
       normalization_parser(
         // don't skip normalization:
         false,
@@ -19,7 +19,7 @@ Json_PMP_Parser::Json_PMP_Parser(
         [this](std::vector<El::BigFloat> &&result) {
           this->result.normalization = std::move(result);
         },
-        [] { El::LogicError(R"(Skipping "normalization" not allowed)"); }),
+        [] { LOGIC_ERROR(R"(Skipping "normalization" not allowed)"); }),
       matrices_parser(
         // don't skip matrices array:
         false,
@@ -35,7 +35,7 @@ Json_PMP_Parser::Json_PMP_Parser(
             }
         },
         [] {
-          El::LogicError(
+          LOGIC_ERROR(
             R"(Skipping "PositiveMatrixWithPrefactorArray" not allowed)");
         },
         // Skip some matrices according to their indices:
@@ -52,7 +52,7 @@ Json_PMP_Parser::element_parser(const std::string &key)
     return normalization_parser;
   if(key == "PositiveMatrixWithPrefactorArray")
     return matrices_parser;
-  El::RuntimeError("Json_PMP_Parser: Unexpected key=", key);
+  RUNTIME_ERROR("Json_PMP_Parser: Unexpected key=", key);
 }
 void Json_PMP_Parser::clear_result()
 {

--- a/src/pmp_read/read_json/Json_Polynomial_Parser.hxx
+++ b/src/pmp_read/read_json/Json_Polynomial_Parser.hxx
@@ -23,10 +23,8 @@ public:
   void clear_result() override { result.coefficients.clear(); }
   void on_element_parsed(element_type &&value, size_t index) override
   {
-    if(index != result.coefficients.size())
-      El::RuntimeError(
-        "Json_Polynomial_Parser: Invalid polynomial coefficient index=", index,
-        ", expected ", result.coefficients.size());
+    ASSERT(index == result.coefficients.size(), "index=", index,
+           ", result.coefficients.size()=", result.coefficients.size());
     result.coefficients.push_back(std::forward<element_type>(value));
   }
   void on_element_skipped(size_t index) override {}

--- a/src/pmp_read/read_json/Json_Polynomial_Vector_Parser.hxx
+++ b/src/pmp_read/read_json/Json_Polynomial_Vector_Parser.hxx
@@ -25,9 +25,8 @@ public:
   void clear_result() override { result.clear(); }
   void on_element_parsed(element_type &&value, size_t index) override
   {
-    if(index != result.size())
-      El::RuntimeError("Json_Polynomial_Vector_Parser: Invalid index=", index,
-                       ", expected ", result.size());
+    ASSERT(index == result.size(), "index=", index, ", expected ",
+           result.size());
     result.push_back(value);
   }
   void on_element_skipped(size_t index) override {}

--- a/src/pmp_read/read_json/Json_Positive_Matrix_With_Prefactor_Parser.hxx
+++ b/src/pmp_read/read_json/Json_Positive_Matrix_With_Prefactor_Parser.hxx
@@ -49,15 +49,13 @@ protected:
       return polynomials_parser;
     if(key == "DampedRational")
       return prefactor_parser;
-    El::RuntimeError(
-      "Json_Positive_Matrix_With_Prefactor_Parser: unknown key=", key);
+    RUNTIME_ERROR("unknown key=", key);
   }
 
 public:
   value_type get_result() override
   {
-    if(!polynomials.has_value())
-      El::RuntimeError("rank=", El::mpi::Rank(), ": polynomials not found");
+    ASSERT(polynomials.has_value(), "polynomials not found");
     const auto matrix = to_matrix(std::move(polynomials).value());
     // TODO add move ctor for Polynomial_Vector_Matrix?
     return Polynomial_Vector_Matrix(matrix, prefactor, std::nullopt,

--- a/src/pmp_read/read_json/read_json.cxx
+++ b/src/pmp_read/read_json/read_json.cxx
@@ -24,14 +24,13 @@ read_json(const std::filesystem::path &input_path,
     }
   catch(std::exception &e)
     {
-      El::RuntimeError("Failed to parse ", input_path,
-                       ": offset=", wrapper.Tell(), ": ", e.what());
+      RUNTIME_ERROR("Failed to parse ", input_path,
+                    ": offset=", wrapper.Tell(), ": ", e.what());
     }
   if(res.IsError())
     {
-      El::RuntimeError("Failed to parse ", input_path,
-                       ": offset=", res.Offset(),
-                       ": error: ", rapidjson::GetParseError_En(res.Code()));
+      RUNTIME_ERROR("Failed to parse ", input_path, ": offset=", res.Offset(),
+                    ": error: ", rapidjson::GetParseError_En(res.Code()));
     }
   return result;
 }

--- a/src/pmp_read/read_mathematica/parse_SDP/parse_SDP.cxx
+++ b/src/pmp_read/read_mathematica/parse_SDP/parse_SDP.cxx
@@ -1,6 +1,7 @@
 #include "parse_vector.hxx"
 #include "parse_generic.hxx"
 #include "pmp/Polynomial_Vector_Matrix.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <algorithm>
 #include <iterator>
@@ -24,7 +25,7 @@ parse_SDP(const char *begin, const char *end,
     std::search(begin, end, SDP_literal.begin(), SDP_literal.end()));
   if(SDP_start == end)
     {
-      throw std::runtime_error("Could not find 'SDP['");
+      RUNTIME_ERROR("Could not find 'SDP['");
     }
   if(SDP_start != begin)
     {
@@ -32,7 +33,7 @@ parse_SDP(const char *begin, const char *end,
       if(previous_char != ' ' && previous_char != '\t' && previous_char != '\n'
          && previous_char != '\r' && previous_char != ')')
         {
-          throw std::runtime_error("Invalid sequence: '"
+          RUNTIME_ERROR("Invalid sequence: '"
                                    + (previous_char + SDP_literal)
                                    + "'.  Is this an SDP file?");
         }
@@ -49,7 +50,7 @@ parse_SDP(const char *begin, const char *end,
   const char *comma(std::find(end_objective, end, ','));
   if(comma == end)
     {
-      throw std::runtime_error("Missing comma after objective");
+      RUNTIME_ERROR("Missing comma after objective");
     }
 
   parse_vector(std::next(comma), end, temp_vector);
@@ -62,7 +63,7 @@ parse_SDP(const char *begin, const char *end,
   comma = std::find(end_objective, end, ',');
   if(comma == end)
     {
-      throw std::runtime_error("Missing comma after normalization");
+      RUNTIME_ERROR("Missing comma after normalization");
     }
 
   const char *end_matrices(parse_matrices(std::next(comma), end,
@@ -72,7 +73,7 @@ parse_SDP(const char *begin, const char *end,
   const auto close_bracket(std::find(end_matrices, end, ']'));
   if(close_bracket == end)
     {
-      throw std::runtime_error("Missing ']' at end of SDP");
+      RUNTIME_ERROR("Missing ']' at end of SDP");
     }
   return std::next(close_bracket);
 }

--- a/src/pmp_read/read_mathematica/parse_SDP/parse_generic.hxx
+++ b/src/pmp_read/read_mathematica/parse_SDP/parse_generic.hxx
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "pmp/Polynomial_Vector_Matrix.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <algorithm>
 #include <iterator>
@@ -30,7 +31,7 @@ const char *parse_generic(const char *begin, const char *end,
   const auto open_brace(std::find(begin, end, '{'));
   if(open_brace == end)
     {
-      throw std::runtime_error("Could not find '{' to start array");
+      RUNTIME_ERROR("Could not find '{' to start array");
     }
 
   auto delimiter(open_brace);
@@ -44,7 +45,7 @@ const char *parse_generic(const char *begin, const char *end,
                                      delimiters.end());
       if(delimiter == end)
         {
-          throw std::runtime_error("Missing '}' at end of array");
+          RUNTIME_ERROR("Missing '}' at end of array");
         }
     }
   while(*delimiter != '}');

--- a/src/pmp_read/read_mathematica/parse_SDP/parse_matrices.cxx
+++ b/src/pmp_read/read_mathematica/parse_SDP/parse_matrices.cxx
@@ -16,7 +16,7 @@ const char *parse_matrices(
   const auto open_brace(std::find(begin, end, '{'));
   if(open_brace == end)
     {
-      throw std::runtime_error("Could not find '{' to start array");
+      RUNTIME_ERROR("Could not find '{' to start array");
     }
 
   auto delimiter(open_brace);
@@ -39,7 +39,7 @@ const char *parse_matrices(
                                      delimiters.end());
       if(delimiter == end)
         {
-          throw std::runtime_error(
+          RUNTIME_ERROR(
             "Missing '}' at end of array of PositiveMatrixWithPrefactor");
         }
   } while(*delimiter != '}');

--- a/src/pmp_read/read_mathematica/parse_SDP/parse_matrix/parse_damped_rational.cxx
+++ b/src/pmp_read/read_mathematica/parse_SDP/parse_matrix/parse_damped_rational.cxx
@@ -25,7 +25,7 @@ const char *parse_damped_rational(const char *begin, const char *end,
           auto comma(std::find(current, end, ','));
           if(comma == end)
             {
-              throw std::runtime_error(
+              RUNTIME_ERROR(
                 "Missing a comma when parsing a constant as a DampedRational. "
                 " The parsed string is\n\t'"
                 + std::string(current, end) + "'");
@@ -39,13 +39,13 @@ const char *parse_damped_rational(const char *begin, const char *end,
     std::search(begin, end, damped_literal.begin(), damped_literal.end()));
   if(damped_start == end)
     {
-      throw std::runtime_error("Could not find '" + damped_literal + "'");
+      RUNTIME_ERROR("Could not find '" + damped_literal + "'");
     }
 
   auto comma(std::find(damped_start, end, ','));
   if(comma == end)
     {
-      throw std::runtime_error("Missing comma after DampedRational.constant");
+      RUNTIME_ERROR("Missing comma after DampedRational.constant");
     }
   auto constant_start(std::next(damped_start, damped_literal.size()));
   damped_rational.constant = Boost_Float(parse_number(constant_start, comma));
@@ -56,14 +56,14 @@ const char *parse_damped_rational(const char *begin, const char *end,
   comma = std::find(end_poles, end, ',');
   if(comma == end)
     {
-      throw std::runtime_error("Missing comma after DampedRational.poles");
+      RUNTIME_ERROR("Missing comma after DampedRational.poles");
     }
 
   auto start_base(std::next(comma));
   comma = std::find(start_base, end, ',');
   if(comma == end)
     {
-      throw std::runtime_error("Missing comma after DampedRational.base");
+      RUNTIME_ERROR("Missing comma after DampedRational.base");
     }
   damped_rational.base = Boost_Float(parse_number(start_base, comma));
 
@@ -71,7 +71,7 @@ const char *parse_damped_rational(const char *begin, const char *end,
   const auto close_bracket(std::find(start_variable, end, ']'));
   if(close_bracket == end)
     {
-      throw std::runtime_error("Missing ']' at end of DampedRational");
+      RUNTIME_ERROR("Missing ']' at end of DampedRational");
     }
 
   return std::next(close_bracket);

--- a/src/pmp_read/read_mathematica/parse_SDP/parse_matrix/parse_matrix.cxx
+++ b/src/pmp_read/read_mathematica/parse_SDP/parse_matrix/parse_matrix.cxx
@@ -18,7 +18,7 @@ parse_matrix(const char *begin, const char *end,
     std::search(begin, end, matrix_literal.begin(), matrix_literal.end()));
   if(matrix_start == end)
     {
-      throw std::runtime_error("Could not find '" + matrix_literal + "'");
+      RUNTIME_ERROR("Could not find '" + matrix_literal + "'");
     }
 
   Damped_Rational prefactor;
@@ -29,7 +29,7 @@ parse_matrix(const char *begin, const char *end,
   auto comma(std::find(end_damped_rational, end, ','));
   if(comma == end)
     {
-      throw std::runtime_error("Missing comma after DampedRational");
+      RUNTIME_ERROR("Missing comma after DampedRational");
     }
 
   std::vector<std::vector<Polynomial_Vector>> polynomials;
@@ -39,7 +39,7 @@ parse_matrix(const char *begin, const char *end,
   const char *close_bracket(std::find(end_polynomials, end, ']'));
   if(close_bracket == end)
     {
-      throw std::runtime_error("Missing ']' at end of SDP");
+      RUNTIME_ERROR("Missing ']' at end of SDP");
     }
 
   matrix = std::make_unique<Polynomial_Vector_Matrix>(

--- a/src/pmp_read/read_mathematica/parse_SDP/parse_polynomial.cxx
+++ b/src/pmp_read/read_mathematica/parse_SDP/parse_polynomial.cxx
@@ -1,5 +1,6 @@
 #include "is_valid_char.hxx"
 #include "pmp/Polynomial.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <algorithm>
 #include <iterator>
@@ -12,8 +13,8 @@ inline void check_iterator(const char character, const char *begin,
 {
   if(iterator == end)
     {
-      throw std::runtime_error("Invalid polynomial string after '"s + character
-                               + "': " + std::string(begin, end));
+      RUNTIME_ERROR("Invalid polynomial string after '", character
+                               , "': " , std::string(begin, end));
     }
 }
 
@@ -25,7 +26,7 @@ parse_polynomial(const char *begin, const char *end, Polynomial &polynomial)
     std::find_first_of(begin, end, delimiters.begin(), delimiters.end()));
   if(delimiter == end)
     {
-      throw std::runtime_error("Missing '}' at end of array of polynomials");
+      RUNTIME_ERROR("Missing '}' at end of array of polynomials");
     }
 
   std::string mantissa;

--- a/src/pmp_read/read_mathematica/parse_SDP/parse_vector.hxx
+++ b/src/pmp_read/read_mathematica/parse_SDP/parse_vector.hxx
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "parse_number.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <El.hpp>
 
@@ -13,14 +14,14 @@ parse_vector(const char *begin, const char *end, std::vector<T> &result_vector)
   const auto open_brace(std::find(begin, end, '{'));
   if(open_brace == end)
     {
-      throw std::runtime_error("Missing '{' at beginning of array of numbers");
+      RUNTIME_ERROR("Missing '{' at beginning of array of numbers");
     }
   auto start_element(std::next(open_brace));
 
   const auto close_brace(std::find(start_element, end, '}'));
   if(close_brace == end)
     {
-      throw std::runtime_error("Missing '}' at end of array of numbers");
+      RUNTIME_ERROR("Missing '}' at end of array of numbers");
     }
 
   auto comma(open_brace);

--- a/src/pmp_read/read_mathematica/read_mathematica.cxx
+++ b/src/pmp_read/read_mathematica/read_mathematica.cxx
@@ -1,4 +1,5 @@
 #include "pmp_read/PMP_File_Parse_Result.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <boost/interprocess/file_mapping.hpp>
 #include <boost/interprocess/mapped_region.hpp>
@@ -20,7 +21,7 @@ PMP_File_Parse_Result read_mathematica(
   std::ifstream input_stream(input_path);
   if(!input_stream.good())
     {
-      El::RuntimeError("Unable to open input: ", input_path);
+      RUNTIME_ERROR("Unable to open input: ", input_path);
     }
 
   boost::interprocess::file_mapping mapped_file(

--- a/src/pmp_read/read_nsv_file_list.cxx
+++ b/src/pmp_read/read_nsv_file_list.cxx
@@ -1,3 +1,5 @@
+#include "sdpb_util/assert.hxx"
+
 #include <filesystem>
 #include <boost/algorithm/string.hpp>
 
@@ -17,7 +19,7 @@ std::vector<fs::path> read_nsv_file_list(const fs::path &input_file)
   infile.read(file_contents.data(), file_size);
   if(!infile.good())
     {
-      throw std::runtime_error("Unable to read: " + input_file.string());
+      RUNTIME_ERROR("Unable to read: " , input_file);
     }
   std::vector<fs::path> result;
   using namespace std::literals;

--- a/src/pmp_read/read_xml/Xml_Parser/on_start_element.cxx
+++ b/src/pmp_read/read_xml/Xml_Parser/on_start_element.cxx
@@ -8,12 +8,11 @@ void Xml_Parser::on_start_element(const std::string &element_name)
     {
       if(!objective_state.xml_on_start_element(element_name)
          && !polynomial_vector_matrices_state.xml_on_start_element(
-              element_name))
+           element_name))
         {
-          throw std::runtime_error(
-            "Invalid input file.  Expected '" + objective_state.name + "' or '"
-            + polynomial_vector_matrices_state.name
-            + "' inside 'sdp', but found '" + element_name + "'");
+          RUNTIME_ERROR("Invalid input file. Expected '", objective_state.name,
+                        "' or '", polynomial_vector_matrices_state.name,
+                        "' inside 'sdp', but found '", element_name, "'");
         }
     }
   else if(element_name == sdp_name)
@@ -22,8 +21,7 @@ void Xml_Parser::on_start_element(const std::string &element_name)
     }
   else
     {
-      throw std::runtime_error(
-        "Invalid input file.  Expected 'sdp' but found '" + element_name
-        + "'");
+      RUNTIME_ERROR("Invalid input file. Expected 'sdp' but found '"
+                    + element_name + "'");
     }
 }

--- a/src/pmp_read/read_xml/Xml_Polynomial_Vector_Matrix_State.hxx
+++ b/src/pmp_read/read_xml/Xml_Polynomial_Vector_Matrix_State.hxx
@@ -26,7 +26,8 @@ public:
 
   Xml_Polynomial_Vector_Matrix_State(
     const std::vector<std::string> &names, const size_t &offset,
-    const std::function<void(Xml_Polynomial_Vector_Matrix_State& matrix_state)> &process_matrix)
+    const std::function<void(Xml_Polynomial_Vector_Matrix_State &matrix_state)>
+      &process_matrix)
       : name(names.at(offset)),
         process_matrix(process_matrix),
         elements_state(
@@ -53,11 +54,11 @@ public:
                   || sample_scalings_state.xml_on_start_element(element_name)
                   || bilinear_basis_state.xml_on_start_element(element_name)))
           {
-            throw std::runtime_error(
+            RUNTIME_ERROR(
               "Inside polynomialVectorMatrix, expected 'rows', 'cols', "
               "'elements', 'sample_points', 'sample_scalings', or "
-              "'bilinear_basis', but found '"
-              + element_name + "'");
+              "'bilinear_basis', but found '",
+              element_name, "'");
           }
       }
     else if(element_name == name)

--- a/src/pmp_read/read_xml/read_xml.cxx
+++ b/src/pmp_read/read_xml/read_xml.cxx
@@ -43,7 +43,7 @@ namespace
     va_start(args, msg);
     vprintf(msg, args);
     va_end(args);
-    throw std::runtime_error("Invalid Input file");
+    RUNTIME_ERROR("Invalid Input file");
   }
 }
 
@@ -104,8 +104,7 @@ read_xml(const std::filesystem::path &input_file,
 
   if(xmlSAXUserParseFile(&xml_handlers, &input_parser, input_file.c_str()) < 0)
     {
-      throw std::runtime_error("Unable to parse input file: "
-                               + input_file.string());
+      RUNTIME_ERROR("Unable to parse input file: ", input_file);
     }
 
   // Overwrite the objective with whatever is in the last file

--- a/src/pvm2functions/main.cxx
+++ b/src/pvm2functions/main.cxx
@@ -1,5 +1,6 @@
 #include "sdpb_util/Boost_Float.hxx"
 #include "pmp_read/pmp_read.hxx"
+#include "sdpb_util/assert.hxx"
 
 namespace fs = std::filesystem;
 
@@ -20,7 +21,7 @@ int main(int argc, char **argv)
     {
       // TODO fix parallel
       if(El::mpi::Size() > 1)
-        El::RuntimeError("pvm2functions cannot work in parallel!");
+        RUNTIME_ERROR("pvm2functions cannot work in parallel!");
 
       int precision;
       std::vector<fs::path> input_files;
@@ -30,16 +31,9 @@ int main(int argc, char **argv)
       El::gmp::SetPrecision(precision);
       Boost_Float::default_precision(precision * log(2) / log(10));
 
-      if(output_path == ".")
-        {
-          throw std::runtime_error("Output file '" + output_path.string()
-                                   + "' is a directory");
-        }
-      if(fs::exists(output_path) && fs::is_directory(output_path))
-        {
-          throw std::runtime_error("Output file '" + output_path.string()
-                                   + "' exists and is a directory");
-        }
+      ASSERT(output_path != ".", "Output file is a directory: ", output_path);
+      ASSERT(!(fs::exists(output_path) && fs::is_directory(output_path)),
+             "Output file exists and is a directory: ", output_path);
       const auto pmp = read_polynomial_matrix_program(input_files);
       write_functions(output_path, pmp.objective, pmp.matrices);
     }

--- a/src/pvm2functions/parse_command_line.cxx
+++ b/src/pvm2functions/parse_command_line.cxx
@@ -1,3 +1,5 @@
+#include "sdpb_util/assert.hxx"
+
 #include <filesystem>
 #include <vector>
 #include <iostream>
@@ -34,23 +36,16 @@ void parse_command_line(int argc, char **argv, int &precision,
     }
   catch(std::logic_error &e)
     {
-      throw std::runtime_error("Invalid precision: '" + precision_string
-                               + "'");
+      RUNTIME_ERROR("Invalid precision: '" + precision_string + "'");
     }
-  if(pos != precision_string.size())
-    {
-      throw std::runtime_error("Precision has trailing characters: '"
-                               + precision_string.substr(pos) + "'");
-    }
+  ASSERT(pos == precision_string.size(),
+         "Precision has trailing characters: '",
+         precision_string.substr(pos) + "'");
 
   input_files.insert(input_files.end(), argv + 2, argv + argc - 1);
   for(auto &file : input_files)
     {
-      if(!fs::exists(file))
-        {
-          throw std::runtime_error("Input file '" + file.string()
-                                   + "' does not exist");
-        }
+      ASSERT(fs::exists(file), "Input file does not exist: ", file);
     }
   output_dir = argv[argc - 1];
 }

--- a/src/pvm2functions/write_functions.cxx
+++ b/src/pvm2functions/write_functions.cxx
@@ -119,7 +119,7 @@ void write_functions(const fs::path &output_path,
           }
           break;
         default:
-          throw std::runtime_error(
+          RUNTIME_ERROR(
             "Too large a dimension.  Only 1x1 and 2x2 supported: "
             + std::to_string(block->polynomials.Height()));
         }

--- a/src/pvm2sdp/main.cxx
+++ b/src/pvm2sdp/main.cxx
@@ -32,16 +32,10 @@ int main(int argc, char **argv)
 
       auto pmp = read_polynomial_matrix_program(input_files);
       Output_SDP sdp(pmp, command_arguments, timers);
-      if(output_path == ".")
-        {
-          throw std::runtime_error("Output file '" + output_path.string()
-                                   + "' is a directory");
-        }
-      if(fs::exists(output_path) && fs::is_directory(output_path))
-        {
-          throw std::runtime_error("Output file '" + output_path.string()
-                                   + "' exists and is a directory");
-        }
+      ASSERT(output_path != ".",
+             "Output file is a directory: ", output_path);
+      ASSERT(!(fs::exists(output_path) && fs::is_directory(output_path)),
+             "Output file exists and is a directory: ", output_path);
       write_sdp(output_path, sdp, output_format, timers, debug);
     }
   catch(std::exception &e)

--- a/src/pvm2sdp/parse_command_line.cxx
+++ b/src/pvm2sdp/parse_command_line.cxx
@@ -10,7 +10,8 @@ namespace fs = std::filesystem;
 void parse_command_line(int argc, char **argv,
                         Block_File_Format &output_format, int &precision,
                         std::vector<fs::path> &input_files,
-                        fs::path &output_dir, std::vector<std::string>& command_arguments)
+                        fs::path &output_dir,
+                        std::vector<std::string> &command_arguments)
 {
   std::string usage("pvm2sdp [FORMAT] PRECISION INPUT... OUTPUT\n"
                     "FORMAT (optional): output format, bin (default) or json\n"
@@ -53,24 +54,19 @@ void parse_command_line(int argc, char **argv,
     }
   catch(std::logic_error &e)
     {
-      throw std::runtime_error("Invalid precision: '" + precision_string
-                               + "'");
+      RUNTIME_ERROR("Invalid precision: '" + precision_string + "'");
     }
   if(pos != precision_string.size())
     {
-      throw std::runtime_error("Precision has trailing characters: '"
-                               + precision_string.substr(pos) + "'");
+      RUNTIME_ERROR("Precision has trailing characters: '"
+                    + precision_string.substr(pos) + "'");
     }
   curr_arg_pos++;
 
   input_files.insert(input_files.end(), argv + curr_arg_pos, argv + argc - 1);
   for(auto &file : input_files)
     {
-      if(!fs::exists(file))
-        {
-          throw std::runtime_error("Input file '" + file.string()
-                                   + "' does not exist");
-        }
+      ASSERT(fs::exists(file), "Input file does not exist: ", file);
     }
   output_dir = argv[argc - 1];
 }

--- a/src/sdp2functions/main.cxx
+++ b/src/sdp2functions/main.cxx
@@ -1,4 +1,5 @@
 #include "pmp_read/pmp_read.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <boost/program_options.hpp>
 #include <filesystem>
@@ -19,7 +20,7 @@ int main(int argc, char **argv)
     {
       // TODO fix parallel
       if(El::mpi::Size() > 1)
-        El::RuntimeError("sdp2functions cannot work in parallel!");
+        RUNTIME_ERROR("sdp2functions cannot work in parallel!");
 
       int precision;
       fs::path input_file, output_path;
@@ -57,27 +58,13 @@ int main(int argc, char **argv)
 
       po::notify(variables_map);
 
-      if(!fs::exists(input_file))
-        {
-          throw std::runtime_error("Input file '" + input_file.string()
-                                   + "' does not exist");
-        }
-      if(fs::is_directory(input_file))
-        {
-          throw std::runtime_error("Input file '" + input_file.string()
-                                   + "' is a directory, not a file");
-        }
-
-      if(output_path == ".")
-        {
-          throw std::runtime_error("Output file '" + output_path.string()
-                                   + "' is a directory");
-        }
-      if(fs::exists(output_path) && fs::is_directory(output_path))
-        {
-          throw std::runtime_error("Output file '" + output_path.string()
-                                   + "' exists and is a directory");
-        }
+      ASSERT(fs::exists(input_file),
+             "Input file does not exist: ", input_file);
+      ASSERT(!fs::is_directory(input_file) && input_file != ".",
+             "Input file is a directory, not a file:", input_file);
+      ASSERT(output_path != ".", "Output file is a directory: ", output_path);
+      ASSERT(!(fs::exists(output_path) && fs::is_directory(output_path)),
+             "Output file exists and is a directory: ", output_path);
 
       El::gmp::SetPrecision(precision);
       // El::gmp wants base-2 bits, but boost::multiprecision wants

--- a/src/sdp2functions/write_functions.cxx
+++ b/src/sdp2functions/write_functions.cxx
@@ -102,9 +102,8 @@ void write_functions(
           }
           break;
         default:
-          throw std::runtime_error(
-            "Too large a dimension.  Only 1x1 and 2x2 supported: "
-            + std::to_string(num_rows));
+          RUNTIME_ERROR("Too large a dimension. Only 1x1 and 2x2 supported: ",
+                        num_rows);
         }
 
       for(size_t row(0); row != num_rows; ++row)

--- a/src/sdp2input/main.cxx
+++ b/src/sdp2input/main.cxx
@@ -65,27 +65,13 @@ int main(int argc, char **argv)
 
       po::notify(variables_map);
 
-      if(!fs::exists(input_file))
-        {
-          throw std::runtime_error("Input file '" + input_file.string()
-                                   + "' does not exist");
-        }
-      if(fs::is_directory(input_file))
-        {
-          throw std::runtime_error("Input file '" + input_file.string()
-                                   + "' is a directory, not a file");
-        }
-
-      if(output_path == ".")
-        {
-          throw std::runtime_error("Output file '" + output_path.string()
-                                   + "' is a directory");
-        }
-      if(fs::exists(output_path) && fs::is_directory(output_path))
-        {
-          throw std::runtime_error("Output file '" + output_path.string()
-                                   + "' exists and is a directory");
-        }
+      ASSERT(fs::exists(input_file),
+             "Input file does not exist: ", input_file);
+      ASSERT(!fs::is_directory(input_file) && input_file != ".",
+             "Input file is a directory, not a file:", input_file);
+      ASSERT(output_path != ".", "Output file is a directory: ", output_path);
+      ASSERT(!(fs::exists(output_path) && fs::is_directory(output_path)),
+             "Output file exists and is a directory: ", output_path);
 
       El::gmp::SetPrecision(precision);
       // El::gmp wants base-2 bits, but boost::multiprecision wants

--- a/src/sdp_solve/Archive_Reader.hxx
+++ b/src/sdp_solve/Archive_Reader.hxx
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "sdpb_util/assert.hxx"
+
 #include <El.hpp>
 
 #include <archive.h>
@@ -31,7 +33,7 @@ struct Archive_Reader : public std::streambuf
       {
         const char *const pathname = archive_entry_pathname(entry_ptr);
         const std::string name = pathname ? pathname : "EOF";
-        El::RuntimeError("Archive_Reader: ", name, ": ",
+        RUNTIME_ERROR("Archive_Reader: ", name, ": ",
                          archive_error_string(ptr.get()));
       }
 

--- a/src/sdp_solve/Archive_Reader/Archive_Reader.cxx
+++ b/src/sdp_solve/Archive_Reader/Archive_Reader.cxx
@@ -10,8 +10,7 @@ Archive_Reader::Archive_Reader(const std::filesystem::path &filename)
      || archive_read_open_filename(ptr.get(), filename.c_str(), 10240)
           != ARCHIVE_OK)
     {
-      throw std::runtime_error("Error when opening: '" + filename.string()
-                               + "'");
+      RUNTIME_ERROR("Error when opening ", filename);
     }
   setg(buffer.data(), buffer.data(), buffer.data());
 }

--- a/src/sdp_solve/Archive_Reader/underflow.cxx
+++ b/src/sdp_solve/Archive_Reader/underflow.cxx
@@ -11,7 +11,7 @@ int Archive_Reader::underflow()
         archive_read_data(ptr.get(), buffer.data(), buffer.size()));
       if(num_bytes_read < 0)
         {
-          throw std::runtime_error("Error reading archive.");
+          RUNTIME_ERROR("Error reading archive.");
         }
       if(num_bytes_read > 0)
         {

--- a/src/sdp_solve/Block_Info.hxx
+++ b/src/sdp_solve/Block_Info.hxx
@@ -2,6 +2,7 @@
 
 #include "sdpb_util/Environment.hxx"
 #include "sdpb_util/Verbosity.hxx"
+#include "sdpb_util/assert.hxx"
 #include "sdpb_util/block_mapping/Block_Cost.hxx"
 #include "sdpb_util/block_mapping/MPI_Comm_Wrapper.hxx"
 #include "sdpb_util/block_mapping/MPI_Group_Wrapper.hxx"
@@ -65,9 +66,8 @@ public:
   get_bilinear_pairing_block_size(const size_t index,
                                   const size_t parity) const
   {
-    if(parity == 0 || parity == 1)
-      return num_points.at(index) * dimensions.at(index);
-    throw std::runtime_error("parity should be 0 or 1");
+    ASSERT(parity == 0 || parity == 1);
+    return num_points.at(index) * dimensions.at(index);
   }
   [[nodiscard]] std::vector<size_t> bilinear_pairing_block_sizes() const
   {
@@ -88,7 +88,7 @@ public:
       return even;
     if(parity == 1)
       return dimensions.at(index) * num_points.at(index) - even;
-    throw std::runtime_error("parity should be 0 or 1");
+    RUNTIME_ERROR("parity should be 0 or 1");
   }
   [[nodiscard]] std::vector<size_t> psd_matrix_block_sizes() const
   {

--- a/src/sdp_solve/Block_Info/read_block_costs.cxx
+++ b/src/sdp_solve/Block_Info/read_block_costs.cxx
@@ -1,4 +1,5 @@
 #include "../Block_Info.hxx"
+#include "sdpb_util/assert.hxx"
 #include "sdpb_util/Timers/Timers.hxx"
 
 namespace fs = std::filesystem;
@@ -45,11 +46,9 @@ Block_Info::read_block_costs(const fs::path &sdp_path,
         }
       if(result.size() != num_points.size())
         {
-          throw std::runtime_error(
-            "Incompatible number of entries in '"
-            + block_timings_filename.string() + "'. Expected "
-            + std::to_string(num_points.size()) + " but found "
-            + std::to_string(result.size()));
+          RUNTIME_ERROR("Incompatible number of entries in ",
+                        block_timings_filename, ": expected ",
+                        num_points.size(), " but found ", result.size());
         }
     }
   else

--- a/src/sdp_solve/Block_Info/read_block_info.cxx
+++ b/src/sdp_solve/Block_Info/read_block_info.cxx
@@ -1,6 +1,7 @@
 #include "sdp_solve/Block_Info.hxx"
 #include "sdp_solve/Archive_Reader.hxx"
 #include "pmp2sdp/write_sdp.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <rapidjson/document.h>
 #include <rapidjson/istreamwrapper.h>
@@ -19,14 +20,11 @@ namespace
     rapidjson::IStreamWrapper wrapper(block_info_stream);
     rapidjson::Document document;
     document.ParseStream(wrapper);
-    size_t dim_value = document["dim"].GetInt64();
-    size_t num_points_value = document["num_points"].GetInt64();
-    if(dim_value == 0 || num_points_value == 0)
-      {
-        El::RuntimeError("Unable to parse block_", block_index,
-                         ": dim=", dim_value,
-                         ", num_points=", num_points_value);
-      }
+    const size_t dim_value = document["dim"].GetInt64();
+    const size_t num_points_value = document["num_points"].GetInt64();
+    ASSERT(dim_value != 0 && num_points_value != 0, "Unable to parse block_",
+           block_index, ": dim=", dim_value,
+           ", num_points=", num_points_value);
 
     dimensions.at(block_index) = dim_value;
     num_points.at(block_index) = num_points_value;
@@ -56,7 +54,7 @@ void Block_Info::read_block_info(const fs::path &sdp_path)
                 return parse_num_blocks(stream);
               }
           }
-        El::RuntimeError("Unable to find control.json in sdp input file");
+        RUNTIME_ERROR("Unable to find control.json in sdp input file");
       }());
 
       dimensions.resize(num_blocks);
@@ -71,13 +69,10 @@ void Block_Info::read_block_info(const fs::path &sdp_path)
           if(!boost::algorithm::starts_with(pathname, prefix))
             continue;
           const size_t blockIndex(std::stoll(pathname.substr(prefix.size())));
-          if(blockIndex >= num_blocks)
-            {
-              El::RuntimeError("Invalid block number for entry '", pathname,
-                               "' in '", sdp_path,
-                               ". The block number must be between 0 and ",
-                               num_blocks - 1, ".");
-            }
+          ASSERT(blockIndex < num_blocks, "Invalid block number for entry '",
+                 pathname, "' in '", sdp_path,
+                 ". The block number must be between 0 and ", num_blocks - 1,
+                 ".");
           std::istream stream(&reader);
           parse_block_info_json(blockIndex, stream, dimensions, num_points);
           processed_count++;
@@ -86,12 +81,9 @@ void Block_Info::read_block_info(const fs::path &sdp_path)
         }
       for(size_t block_index(0); block_index != num_blocks; ++block_index)
         {
-          if(dimensions.at(block_index) == 0
-             || num_points.at(block_index) == 0)
-            {
-              El::RuntimeError("Missing block ", block_index,
-                               " from sdp path: ", sdp_path);
-            }
+          ASSERT(dimensions.at(block_index) > 0
+                   && num_points.at(block_index) > 0,
+                 "Missing block ", block_index, " from sdp path: ", sdp_path);
         }
     }
   else

--- a/src/sdp_solve/SDP/SDP/read_block_data/Block_Parser/Block_Parser.hxx
+++ b/src/sdp_solve/SDP/SDP/read_block_data/Block_Parser/Block_Parser.hxx
@@ -19,16 +19,17 @@ struct Block_Parser
     bilinear_bases_even_state, bilinear_bases_odd_state;
 
   Block_Parser()
-      : c_state({"c"s, ""s}), B_state({"B"s, ""s, ""s}),
+      : c_state({"c"s, ""s}),
+        B_state({"B"s, ""s, ""s}),
         bilinear_bases_even_state({"bilinear_bases_even"s, ""s, ""s}),
         bilinear_bases_odd_state({"bilinear_bases_odd"s, ""s, ""s})
   {}
 
-  bool Null() { throw std::runtime_error("Null not allowed"); }
-  bool Bool(bool) { throw std::runtime_error("Bool not allowed"); }
+  bool Null() { RUNTIME_ERROR("Null not allowed"); }
+  bool Bool(bool) { RUNTIME_ERROR("Bool not allowed"); }
   template <typename T> bool parse_integer(const T &i)
   {
-    throw std::runtime_error("Integer not allowed");
+    RUNTIME_ERROR("Integer not allowed");
   }
   bool Int(int i) { return parse_integer(i); }
   bool Uint(unsigned i) { return parse_integer(i); }
@@ -37,15 +38,13 @@ struct Block_Parser
 
   bool Double(double d)
   {
-    throw std::runtime_error(
-      "Invalid input '" + std::to_string(d)
-      + "'.  All floating point numbers must be quoted as strings.");
+    RUNTIME_ERROR("Invalid input '", d,
+                  "'. All floating point numbers must be quoted as strings.");
   }
   bool RawNumber(const Ch *characters, rapidjson::SizeType size, bool)
   {
-    throw std::runtime_error(
-      "Invalid input '" + std::string(characters, size)
-      + "'.  All floating point numbers must be quoted as strings.");
+    RUNTIME_ERROR("Invalid input '", std::string(characters, size),
+                  "'.  All floating point numbers must be quoted as strings.");
   }
   bool StartObject()
   {
@@ -55,8 +54,8 @@ struct Block_Parser
       }
     else
       {
-        throw std::runtime_error(
-          "Invalid input.  No objects allowed inside the main object.");
+        RUNTIME_ERROR(
+          "Invalid input. No objects allowed inside the main object.");
       }
     return true;
   }

--- a/src/sdp_solve/SDP/SDP/read_block_data/Block_Parser/EndArray.cxx
+++ b/src/sdp_solve/SDP/SDP/read_block_data/Block_Parser/EndArray.cxx
@@ -1,4 +1,5 @@
 #include "Block_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Block_Parser::EndArray(rapidjson::SizeType)
 {
@@ -26,14 +27,14 @@ bool Block_Parser::EndArray(rapidjson::SizeType)
         }
       else
         {
-          throw std::runtime_error(
+          RUNTIME_ERROR(
             "INTERNAL ERROR: Ending an array inside the main object.");
         }
     }
   else
     {
-      throw std::runtime_error(
-        "Invalid input file.  Ending an array outside of the main object.");
+      RUNTIME_ERROR(
+        "Invalid input file. Ending an array outside of the main object.");
     }
   return true;
 }

--- a/src/sdp_solve/SDP/SDP/read_block_data/Block_Parser/Key.cxx
+++ b/src/sdp_solve/SDP/SDP/read_block_data/Block_Parser/Key.cxx
@@ -1,4 +1,5 @@
 #include "Block_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Block_Parser::Key(const Ch *str, rapidjson::SizeType length, bool)
 {
@@ -7,25 +8,23 @@ bool Block_Parser::Key(const Ch *str, rapidjson::SizeType length, bool)
     {
       if(parsing_bilinear_bases_even)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '"
-                                   + bilinear_bases_even_state.name + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key,
+                        "' inside '", bilinear_bases_even_state.name, "'.");
         }
       else if(parsing_bilinear_bases_odd)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '"
-                                   + bilinear_bases_odd_state.name + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key,
+                        "' inside '", bilinear_bases_odd_state.name, "'.");
         }
       else if(parsing_c)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '" + c_state.name + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key,
+                        "' inside '", c_state.name, "'.");
         }
       else if(parsing_B)
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside '" + B_state.name + "'.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key,
+                        "' inside '", B_state.name, "'.");
         }
       if(key == bilinear_bases_even_state.name)
         {
@@ -45,14 +44,13 @@ bool Block_Parser::Key(const Ch *str, rapidjson::SizeType length, bool)
         }
       else
         {
-          throw std::runtime_error("Invalid input file.  Found the key '" + key
-                                   + "' inside the main object.");
+          RUNTIME_ERROR("Invalid input file. Found the key '", key,
+                        "' inside the main object.");
         }
     }
   else
     {
-      throw std::runtime_error("Found a key outside of the main object: "
-                               + key);
+      RUNTIME_ERROR("Found a key outside of the main object: ", key);
     }
   return true;
 }

--- a/src/sdp_solve/SDP/SDP/read_block_data/Block_Parser/StartArray.cxx
+++ b/src/sdp_solve/SDP/SDP/read_block_data/Block_Parser/StartArray.cxx
@@ -1,4 +1,5 @@
 #include "Block_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Block_Parser::StartArray()
 {
@@ -22,15 +23,15 @@ bool Block_Parser::StartArray()
         }
       else
         {
-          throw std::runtime_error(
-            "Invalid input file.  Found an array not inside " + c_state.name
-            + ", " + B_state.name + ", " + bilinear_bases_even_state.name
-            + ", " + bilinear_bases_odd_state.name + ".");
+          RUNTIME_ERROR("Invalid input file. Found an array not inside ",
+                        c_state.name, ", ", B_state.name, ", ",
+                        bilinear_bases_even_state.name, ", ",
+                        bilinear_bases_odd_state.name, ".");
         }
     }
   else
     {
-      throw std::runtime_error("Found an array outside of the main object.");
+      RUNTIME_ERROR("Found an array outside of the main object.");
     }
   return true;
 }

--- a/src/sdp_solve/SDP/SDP/read_block_data/Block_Parser/String.cxx
+++ b/src/sdp_solve/SDP/SDP/read_block_data/Block_Parser/String.cxx
@@ -1,4 +1,5 @@
 #include "Block_Parser.hxx"
+#include "sdpb_util/assert.hxx"
 
 bool Block_Parser::String(const Ch *str, rapidjson::SizeType length, bool)
 {
@@ -23,15 +24,14 @@ bool Block_Parser::String(const Ch *str, rapidjson::SizeType length, bool)
         }
       else
         {
-          throw std::runtime_error(
-            "Invalid input file.  Unexpected string in the main object: '" + s
-            + "'");
+          RUNTIME_ERROR(
+            "Invalid input file. Unexpected string in the main object: '", s,
+            "'");
         }
     }
   else
     {
-      throw std::runtime_error("Found a string outside of the main object: '"
-                               + s + "'");
+      RUNTIME_ERROR("Found a string outside of the main object: '", s, "'");
     }
   return true;
 }

--- a/src/sdp_solve/SDP/SDP/read_block_data/SDP_Block_Data.cxx
+++ b/src/sdp_solve/SDP/SDP/read_block_data/SDP_Block_Data.cxx
@@ -4,6 +4,7 @@
 #include "sdp_solve/SDP/SDP/set_bases_blocks.hxx"
 #include "sdpb_util/Number_State.hxx"
 #include "sdpb_util/Vector_State.hxx"
+#include "sdpb_util/assert.hxx"
 #include "sdpb_util/boost_serialization.hxx"
 
 #include <boost/archive/binary_iarchive.hpp>
@@ -59,11 +60,9 @@ void parse_block_data(std::istream &block_stream, Block_File_Format format,
       boost::archive::binary_iarchive ar(block_stream);
       mp_bitcnt_t precision;
       ar >> precision;
-      if(precision != El::gmp::Precision())
-        {
-          El::RuntimeError("Read GMP precision: ", precision,
-                           ", expected: ", El::gmp::Precision());
-        }
+      ASSERT(precision == El::gmp::Precision(),
+             "Read GMP precision: ", precision,
+             ", expected: ", El::gmp::Precision());
       ar >> constraint_matrix;
       ar >> constraint_constants;
       ar >> bilinear_bases_even;
@@ -83,7 +82,7 @@ void parse_block_data(std::istream &block_stream, Block_File_Format format,
     }
   else
     {
-      El::RuntimeError("Unknown Block_File_Format: ", format);
+      RUNTIME_ERROR("Unknown Block_File_Format: ", format);
     }
 }
 

--- a/src/sdp_solve/SDP/SDP/read_objectives.cxx
+++ b/src/sdp_solve/SDP/SDP/read_objectives.cxx
@@ -1,5 +1,6 @@
 #include "sdp_solve/SDP.hxx"
 #include "sdp_solve/Archive_Reader.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <rapidjson/document.h>
 #include <rapidjson/istreamwrapper.h>
@@ -41,10 +42,7 @@ void read_objectives(const fs::path &sdp_path, const El::Grid &grid,
                      Timers &timers)
 {
   Scoped_Timer timer(timers, "read_objectives");
-  if(!fs::exists(sdp_path))
-    {
-      El::RuntimeError("SDP path '" + sdp_path.string() + "' does not exist");
-    }
+  ASSERT(fs::exists(sdp_path), "SDP path does not exist: ", sdp_path);
 
   const std::string objectives_name("objectives.json");
   if(fs::is_regular_file(sdp_path))
@@ -57,13 +55,13 @@ void read_objectives(const fs::path &sdp_path, const El::Grid &grid,
           if(objectives_name == archive_entry_pathname(reader.entry_ptr))
             {
               std::istream stream(&reader);
-              read_objectives_stream(grid, stream,
-                                     objective_const, dual_objective_b);
+              read_objectives_stream(grid, stream, objective_const,
+                                     dual_objective_b);
             }
         }
       if(dual_objective_b.Height() == 0)
         {
-          throw std::runtime_error("Unable to read objectives from input");
+          RUNTIME_ERROR("Unable to read objective from input");
         }
     }
   else

--- a/src/sdp_solve/SDP_Solver/load_checkpoint/load_checkpoint.cxx
+++ b/src/sdp_solve/SDP_Solver/load_checkpoint/load_checkpoint.cxx
@@ -1,4 +1,5 @@
 #include "sdp_solve/SDP_Solver.hxx"
+#include "sdpb_util/assert.hxx"
 
 namespace fs = std::filesystem;
 
@@ -10,8 +11,9 @@ bool load_text_checkpoint(const fs::path &checkpoint_directory,
                           const Verbosity &verbosity, SDP_Solver &solver);
 
 bool SDP_Solver::load_checkpoint(const fs::path &checkpoint_directory,
-                                 const Block_Info &block_info, const Verbosity &verbosity,
-  const bool &require_initial_checkpoint)
+                                 const Block_Info &block_info,
+                                 const Verbosity &verbosity,
+                                 const bool &require_initial_checkpoint)
 {
   bool valid_checkpoint(
     load_binary_checkpoint(checkpoint_directory, verbosity, *this)
@@ -19,8 +21,8 @@ bool SDP_Solver::load_checkpoint(const fs::path &checkpoint_directory,
                             verbosity, *this));
   if(!valid_checkpoint && require_initial_checkpoint)
     {
-      throw std::runtime_error("Unable to load checkpoint from directory: "
-                               + checkpoint_directory.string());
+      RUNTIME_ERROR("Unable to load checkpoint from directory: ",
+                    checkpoint_directory);
     }
   return valid_checkpoint;
 }

--- a/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/synchronize_Q.cxx
+++ b/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/synchronize_Q.cxx
@@ -1,5 +1,6 @@
 // Synchronize the results back to the global Q.
 
+#include "sdpb_util/assert.hxx"
 #include "sdpb_util/Timers/Timers.hxx"
 
 #include <El.hpp>
@@ -15,7 +16,7 @@ namespace
         std::vector<char> error_string(MPI_MAX_ERROR_STRING);
         int lengthOfErrorString;
         MPI_Error_string(mpi_error, error_string.data(), &lengthOfErrorString);
-        El::RuntimeError(std::string(error_string.data()));
+        RUNTIME_ERROR(std::string(error_string.data()));
       }
   }
 }

--- a/src/sdp_solve/SDP_Solver/save_checkpoint.cxx
+++ b/src/sdp_solve/SDP_Solver/save_checkpoint.cxx
@@ -1,4 +1,5 @@
 #include "../SDP_Solver.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <filesystem>
 #include <boost/property_tree/json_parser.hpp>
@@ -48,9 +49,9 @@ void SDP_Solver::save_checkpoint(
     }
   else if(!is_directory(checkpoint_directory))
     {
-      throw std::runtime_error("Checkpoint directory '"
-                               + checkpoint_directory.string()
-                               + "'already exists, but is not a directory");
+      RUNTIME_ERROR(
+        "Checkpoint directory already exists, but is not a directory: ",
+        checkpoint_directory);
     }
   if(backup_generation)
     {
@@ -93,10 +94,8 @@ void SDP_Solver::save_checkpoint(
             }
           else
             {
-              std::stringstream ss;
-              ss << "Error writing checkpoint file '" << checkpoint_filename
-                 << "'.  Exceeded max retries.\n";
-              throw std::runtime_error(ss.str());
+              RUNTIME_ERROR("Error writing checkpoint file ",
+                            checkpoint_filename, ":  Exceeded max retries.");
             }
         }
     }

--- a/src/sdp_solve/Write_Solution.cxx
+++ b/src/sdp_solve/Write_Solution.cxx
@@ -1,12 +1,13 @@
 #include "Write_Solution.hxx"
 
+#include "sdpb_util/assert.hxx"
+
 #include <boost/algorithm/string.hpp>
 
 #include <stdexcept>
 #include <vector>
 
-Write_Solution::Write_Solution(const std::string &input)
-    : input_string(input)
+Write_Solution::Write_Solution(const std::string &input) : input_string(input)
 {
   std::vector<std::string> solutions;
   using namespace std::string_literals;
@@ -24,14 +25,14 @@ Write_Solution::Write_Solution(const std::string &input)
             case 'X': matrix_X = true; break;
             case 'Y': matrix_Y = true; break;
             default:
-              throw std::runtime_error(
+              RUNTIME_ERROR(
                 "Invalid argument for writeSolution.  Expected a comma "
                 "separated list containing x, y, X, and/or Y, but found: "
                 + solution);
             }
           break;
         default:
-          throw std::runtime_error(
+          RUNTIME_ERROR(
             "Invalid argument for writeSolution.  Expected a comma "
             "separated list containing x, y, X, and/or Y, but found: "
             + solution);

--- a/src/sdp_solve/read_text_block.hxx
+++ b/src/sdp_solve/read_text_block.hxx
@@ -27,25 +27,18 @@ void read_text_block(Matrix &block, const std::filesystem::path &block_path)
   std::ifstream block_stream(block_path);
   if(!block_stream)
     {
-      throw std::runtime_error("Unable to open checkpoint file: '"
-                               + block_path.string() + "'");
+      RUNTIME_ERROR("Unable to open checkpoint file: ", block_path);
     }
   int64_t file_height, file_width;
   block_stream >> file_height >> file_width;
   if(!block_stream.good())
     {
-      throw std::runtime_error("Corrupted header in file: "
-                               + block_path.string());
+      RUNTIME_ERROR("Corrupted header in file: ", block_path);
     }
-  if(file_height != block.Height() || file_width != block.Width())
-    {
-      std::stringstream ss;
-      ss << "Incompatible checkpoint file: '" << block_path.string()
-         << "'.  Expected dimensions (" << block.Height() << ","
-         << block.Width() << "), but found (" << file_height << ","
-         << file_width << ")";
-      throw std::runtime_error(ss.str());
-    }
+  ASSERT(file_height == block.Height() && file_width == block.Width(),
+         "Incompatible checkpoint file: ", block_path,
+         ":  Expected dimensions (", block.Height(), ",", block.Width(),
+         "), but found (", file_height, ",", file_width, ")");
 
   std::string element;
   for(int64_t row = 0; row < file_height; ++row)
@@ -54,11 +47,7 @@ void read_text_block(Matrix &block, const std::filesystem::path &block_path)
         block_stream >> element;
         set_element(block, row, column, El::BigFloat(element));
       }
-  if(!block_stream.good())
-    {
-      throw std::runtime_error("Corrupted data in file: "
-                               + block_path.string());
-    }
+  ASSERT(block_stream.good(), "Corrupted data in file: ", block_path);
 }
 
 template <typename Matrix>

--- a/src/sdpb/SDPB_Parameters/SDPB_Parameters.cxx
+++ b/src/sdpb/SDPB_Parameters/SDPB_Parameters.cxx
@@ -56,7 +56,8 @@ SDPB_Parameters::SDPB_Parameters(int argc, char *argv[])
     "longer.  "
     "This option is generally useful only when trying to fit a large problem "
     "in a small machine.");
-  basic_options.add_options()("verbosity",
+  basic_options.add_options()(
+    "verbosity",
     po::value<Verbosity>(&verbosity)->default_value(Verbosity::regular),
     "Verbosity.  0 -> no output, 1 -> regular output, 2 -> debug output");
 
@@ -80,8 +81,8 @@ SDPB_Parameters::SDPB_Parameters(int argc, char *argv[])
         {
           if(El::mpi::Rank() == 0)
             {
-		    std::cout << "SDPB v" << SDPB_VERSION_STRING << "\n";
-		    std::cout << cmd_line_options << '\n';
+              std::cout << "SDPB v" << SDPB_VERSION_STRING << "\n";
+              std::cout << cmd_line_options << '\n';
             }
         }
       else if(variables_map.count("version") != 0)
@@ -101,11 +102,7 @@ SDPB_Parameters::SDPB_Parameters(int argc, char *argv[])
             {
               param_path = variables_map["paramFile"].as<fs::path>();
               std::ifstream ifs(param_path);
-              if(!ifs.good())
-                {
-                  throw std::runtime_error("Could not open '"
-                                           + param_path.string() + "'");
-                }
+              ASSERT(ifs.good(), "Could not open '", param_path);
 
               po::store(po::parse_config_file(ifs, cmd_line_options),
                         variables_map);
@@ -113,12 +110,8 @@ SDPB_Parameters::SDPB_Parameters(int argc, char *argv[])
 
           po::notify(variables_map);
 
-          if(!fs::exists(sdp_path))
-            {
-              throw std::runtime_error("sdp directory '"
-                                       + sdp_path.string()
-                                       + "' does not exist");
-            }
+          ASSERT(fs::exists(sdp_path),
+                 "sdp directory does not exist:", sdp_path);
 
           if(variables_map.count("outDir") == 0)
             {
@@ -155,11 +148,7 @@ SDPB_Parameters::SDPB_Parameters(int argc, char *argv[])
             {
               fs::create_directories(out_directory);
               std::ofstream ofs(out_directory / "out.txt");
-              if(!ofs.good())
-                {
-                  throw std::runtime_error("Cannot write to outDir: "
-                                           + out_directory.string());
-                }
+              ASSERT(ofs.good(), "Cannot write to outDir: ", out_directory);
             }
 
           if(El::mpi::Rank() == 0 && verbosity >= Verbosity::regular

--- a/src/sdpb/save_solution.cxx
+++ b/src/sdpb/save_solution.cxx
@@ -21,11 +21,7 @@ namespace
     if(block.DistRank() == block.Root())
       {
         stream << "\n";
-        if(!stream.good())
-          {
-            throw std::runtime_error("Error when writing to: "
-                                     + outfile.string());
-          }
+        ASSERT(stream.good(), "Error when writing to: ", outfile);
       }
   }
 }
@@ -60,11 +56,7 @@ void save_solution(const SDP_Solver &solver,
                  << "primalError     = " << solver.primal_error() << ";\n"
                  << "dualError       = " << solver.dual_error << ";\n"
                  << "Solver runtime  = " << solver_runtime << ";\n";
-      if(!out_stream.good())
-        {
-          throw std::runtime_error("Error when writing to: "
-                                   + output_path.string());
-        }
+      ASSERT(out_stream.good(), "Error when writing to: ", output_path);
     }
   // y is duplicated among cores, so only need to print out copy on
   // the root node.
@@ -83,11 +75,7 @@ void save_solution(const SDP_Solver &solver,
       if(El::mpi::Rank() == 0)
         {
           y_stream << "\n";
-          if(!y_stream.good())
-            {
-              throw std::runtime_error("Error when writing to: "
-                                       + y_path.string());
-            }
+          ASSERT(y_stream.good(), "Error when writing to: ", y_path);
         }
     }
 

--- a/src/sdpb/write_timing.cxx
+++ b/src/sdpb/write_timing.cxx
@@ -43,10 +43,7 @@ void write_timing(const fs::path &checkpoint_out, const Block_Info &block_info,
         {
           block_timings_file << block_timings(row, 0) << "\n";
         }
-      if(!block_timings_file.good())
-        {
-          throw std::runtime_error("Error when writing to: "
-                                   + block_timings_path.string());
-        }
+      ASSERT(block_timings_file.good(),
+             "Error when writing to: ", block_timings_path);
     }
 }

--- a/src/sdpb_util/Number_State.hxx
+++ b/src/sdpb_util/Number_State.hxx
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "assert.hxx"
+
 #include <El.hpp>
 
 #include <libxml2/libxml/parser.h>
@@ -29,8 +31,8 @@ public:
   {
     if(inside)
       {
-        throw std::runtime_error("Invalid input file.  Unexpected element '"
-                                 + element_name + "' inside '" + name + "'");
+        RUNTIME_ERROR("Invalid input file. Unexpected element '", element_name,
+                      "' inside '", name, "'");
       }
     else
       {
@@ -57,7 +59,7 @@ public:
             using namespace std::string_literals;
             if(string_value.str() == "inf"s)
               {
-                value=Float_Type(std::numeric_limits<double>::max());
+                value = Float_Type(std::numeric_limits<double>::max());
               }
             else
               {
@@ -66,8 +68,7 @@ public:
           }
         catch(...)
           {
-            throw std::runtime_error("Invalid NNNN number: '" + string_value.str()
-                                     + "'");
+            RUNTIME_ERROR("Invalid NNNN number: '", string_value.str(), "'");
           }
       }
     return result;
@@ -85,8 +86,8 @@ public:
   // JSON Functions
   void json_key(const std::string &key)
   {
-    throw std::runtime_error("Invalid input file.  Found the key '" + key
-                             + "' when expecting a number.");
+    RUNTIME_ERROR("Invalid input file. Found the key '", key,
+                  "' when expecting a number.");
   }
 
   void json_string(const std::string &s)
@@ -98,7 +99,7 @@ public:
         using namespace std::string_literals;
         if(s == "inf"s)
           {
-            value=Float_Type(std::numeric_limits<double>::max());
+            value = Float_Type(std::numeric_limits<double>::max());
           }
         else
           {
@@ -107,31 +108,31 @@ public:
       }
     catch(...)
       {
-        throw std::runtime_error("Invalid number: '" + s + "'");
+        RUNTIME_ERROR("Invalid number: '", s, "'");
       }
   }
 
   void json_start_array()
   {
-    throw std::runtime_error(
-      "Invalid input file.  Found an array when expecting a number.");
+    RUNTIME_ERROR(
+      "Invalid input file. Found an array when expecting a number.");
   }
 
   void json_end_array()
   {
-    throw std::runtime_error(
-      "Invalid input file.  Found an array end when parsing a number.");
+    RUNTIME_ERROR(
+      "Invalid input file. Found an array end when parsing a number.");
   }
 
   void json_start_object()
   {
-    throw std::runtime_error(
-      "Invalid input file.  Found an object when expecting a number.");
+    RUNTIME_ERROR(
+      "Invalid input file. Found an object when expecting a number.");
   }
 
   void json_end_object()
   {
-    throw std::runtime_error(
-      "Invalid input file.  Found an object end when parsing a number.");
+    RUNTIME_ERROR(
+      "Invalid input file. Found an object end when parsing a number.");
   }
 };

--- a/src/sdpb_util/Timers/Scoped_Timer.cxx
+++ b/src/sdpb_util/Timers/Scoped_Timer.cxx
@@ -1,4 +1,5 @@
 #include "Timers.hxx"
+#include "sdpb_util/assert.hxx"
 
 Scoped_Timer::Scoped_Timer(Timers &timers, const std::string &name)
     : timers(timers),
@@ -21,18 +22,12 @@ Scoped_Timer::start_time() const
 }
 void Scoped_Timer::stop()
 {
-  if(!is_running())
-    {
-      El::RuntimeError("Timer '" + new_prefix + "' already stopped!");
-    }
+  ASSERT(is_running(), "Timer '" + new_prefix + "' already stopped!");
   my_timer.stop();
 
   // This assertion will fail if some of the nested timers is still running:
-  if(timers.prefix != new_prefix)
-    {
-      El::RuntimeError("timers.prefix = '" + timers.prefix + "', expected: '"
-                       + new_prefix + "'");
-    }
+  ASSERT(timers.prefix == new_prefix, "timers.prefix = '" + timers.prefix
+                                        + "', expected: '" + new_prefix + "'");
   timers.prefix = old_prefix;
 }
 const Timer &Scoped_Timer::timer() const

--- a/src/sdpb_util/Timers/Timers.cxx
+++ b/src/sdpb_util/Timers/Timers.cxx
@@ -1,6 +1,7 @@
 #include "Timers.hxx"
 
 #include "sdpb_util/Proc_Meminfo.hxx"
+#include "sdpb_util/assert.hxx"
 
 namespace
 {
@@ -81,10 +82,7 @@ void Timers::write_profile(const std::filesystem::path &path) const
     }
   f << "}" << '\n';
 
-  if(!f.good())
-    {
-      throw std::runtime_error("Error when writing to: " + path.string());
-    }
+  ASSERT(f.good(), "Error when writing to: ", path);
 }
 int64_t Timers::elapsed_milliseconds(const std::string &s) const
 {
@@ -92,10 +90,7 @@ int64_t Timers::elapsed_milliseconds(const std::string &s) const
                          [&s](const std::pair<std::string, Timer> &timer) {
                            return timer.first == s;
                          }));
-  if(iter == named_timers.rend())
-    {
-      throw std::runtime_error("Could not find timing for " + s);
-    }
+  ASSERT(iter != named_timers.rend(), "Could not find timing for ", s);
   return iter->second.elapsed_milliseconds();
 }
 

--- a/src/sdpb_util/Vector_State.hxx
+++ b/src/sdpb_util/Vector_State.hxx
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "assert.hxx"
+
 #include <libxml2/libxml/parser.h>
 #include <vector>
 #include <string>
@@ -46,10 +48,9 @@ public:
       {
         if(!element_state.xml_on_start_element(element_name))
           {
-            throw std::runtime_error("Invalid input file.  Expected '"
-                                     + element_state.name + "' inside Vector '"
-                                     + name + "', but found '" + element_name
-                                     + "'");
+            RUNTIME_ERROR("Invalid input file. Expected '", element_state.name,
+                          "' inside Vector '", name + "', but found '",
+                          element_name, "'");
           }
       }
     else

--- a/src/sdpb_util/assert.hxx
+++ b/src/sdpb_util/assert.hxx
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <El.hpp>
+
+#include <exception>
+
+#define THROW(exception_type, ...)                                            \
+  do                                                                          \
+    {                                                                         \
+      throw exception_type(El::BuildString("in ", __FUNCTION__, "() at ",     \
+                                           __FILE__, ":", __LINE__, ": \n  ", \
+                                           __VA_ARGS__));                     \
+  } while(false)
+
+#define RUNTIME_ERROR(...) THROW(std::runtime_error, __VA_ARGS__)
+
+#define LOGIC_ERROR(...) THROW(std::logic_error, __VA_ARGS__)
+
+#define ASSERT(condition, ...)                                                \
+  do                                                                          \
+    {                                                                         \
+      if(!(condition))                                                        \
+        /* El::BuildString() is necessary in case of empty __VA_ARGS__ */    \
+        RUNTIME_ERROR("Assertion '", #condition, "' failed: \n    ",          \
+                      El::BuildString(__VA_ARGS__));                          \
+  } while(false)

--- a/src/sdpb_util/block_mapping/compute_block_grid_mapping.hxx
+++ b/src/sdpb_util/block_mapping/compute_block_grid_mapping.hxx
@@ -158,10 +158,10 @@ compute_block_grid_mapping(const size_t &procs_per_node,
                 }
             }
         }
-      if(min_block==available_block_maps.at(0).end())
+      if(min_block == available_block_maps.at(0).end())
         {
-          throw std::runtime_error("INTERNAL ERROR: Unable to find any "
-                                   "free processors for remaining blocks");
+          LOGIC_ERROR(
+            "Unable to find any free processors for remaining blocks");
         }
       min_block->cost += block->cost;
       min_block->block_indices.push_back(block->index);

--- a/src/sdpb_util/block_mapping/create_mpi_block_mapping_groups.hxx
+++ b/src/sdpb_util/block_mapping/create_mpi_block_mapping_groups.hxx
@@ -44,19 +44,13 @@ inline void create_mpi_block_mapping_groups(
   // even if there are more nodes than procs.  So this is a sanity
   // check in case we messed up something in
   // compute_block_grid_mapping.
-  if(node_rank_end <= node_rank)
-    {
-      El::LogicError(
-        "Some procs were not covered by compute_block_grid_mapping: "
-        "node=",
-        node_index, ", node_rank=", node_rank, ", rank_end=", node_rank_end);
-    }
-  if(node_rank_end > procs_per_node)
-    {
-      El::LogicError("Block mapping for node=", node_index,
-                     " assumes more than ", procs_per_node,
-                     " processes per node.");
-    }
+  ASSERT(node_rank < node_rank_end,
+         "Some procs were not covered by compute_block_grid_mapping: "
+         "node=",
+         node_index, ", node_rank=", node_rank, ", rank_end=", node_rank_end);
+  ASSERT(node_rank_end <= procs_per_node,
+         "Block mapping for node=", node_index, " assumes more than ",
+         procs_per_node, "processes per node.");
 
   // Create MPI group for [node_rank_begin, node_rank_end)
   {
@@ -65,10 +59,8 @@ inline void create_mpi_block_mapping_groups(
     El::mpi::Incl(node_mpi_group, group_ranks.size(), group_ranks.data(),
                   mpi_group);
   }
-  if(mpi_group == El::mpi::GROUP_NULL)
-    {
-      El::RuntimeError("Block assignment failed for rank=", El::mpi::Rank(),
-                       " at node=", node_index);
-    }
+  ASSERT(mpi_group != El::mpi::GROUP_NULL,
+         "Block assignment failed for rank=", El::mpi::Rank(),
+         " at node=", node_index);
   El::mpi::Create(node_comm, mpi_group, mpi_group_comm);
 }

--- a/src/sdpb_util/copy_matrix.cxx
+++ b/src/sdpb_util/copy_matrix.cxx
@@ -1,5 +1,6 @@
 #include "copy_matrix.hxx"
 #include "Shared_Window_Array.hxx"
+#include "assert.hxx"
 
 void copy_matrix(const El::Matrix<El::BigFloat> &source,
                  El::DistMatrix<El::BigFloat> &destination)
@@ -147,22 +148,17 @@ void copy_matrix_from_root(const El::Matrix<El::BigFloat> &source,
                            El::DistMatrix<El::BigFloat> &destination,
                            const El::mpi::Comm &comm)
 {
-  if(!El::mpi::Congruent(comm, destination.DistComm()))
-    {
-      El::RuntimeError("Wrong communicator for copy_matrix_from_root(); use "
-                       "output.DistComm()");
-    }
+  ASSERT(El::mpi::Congruent(comm, destination.DistComm()),
+         "Wrong communicator for copy_matrix_from_root(); "
+         "use output.DistComm()");
 
   if(comm.Rank() == 0)
     {
       // TODO set matrix size instead?
-      if(source.Height() != destination.Height()
-         || source.Width() != destination.Width())
-        {
-          El::RuntimeError("Incompatible matrix sizes: input: ",
-                           El::DimsString(source, "source"), ", ",
-                           El::DimsString(destination, "destination"));
-        }
+      ASSERT(source.Height() == destination.Height()
+               && source.Width() == destination.Width(),
+             "Incompatible matrix sizes: ", El::DimsString(source, "source"),
+             ", ", El::DimsString(destination, "destination"));
     }
 
   if(comm.Size() == 1)

--- a/src/sdpb_util/json/Abstract_Json_Reader_Handler.hxx
+++ b/src/sdpb_util/json/Abstract_Json_Reader_Handler.hxx
@@ -53,8 +53,8 @@ struct Abstract_Json_Reader_Handler
 #define VIRTUAL_NOT_IMPLEMENTED(func)                                         \
   virtual func [[noreturn]]                                                   \
   {                                                                           \
-    El::RuntimeError("Not implemented: function '", #func, "' in class: '",   \
-                     typeid(*this).name(), "'");                              \
+    RUNTIME_ERROR("Not implemented: function '", #func, "' in class: '",      \
+                  typeid(*this).name(), "'");                                 \
   }
 
   VIRTUAL_NOT_IMPLEMENTED(bool json_default())

--- a/src/sdpb_util/json/Json_Float_Parser.hxx
+++ b/src/sdpb_util/json/Json_Float_Parser.hxx
@@ -44,11 +44,15 @@ public:
                              ? TFloat(std::numeric_limits<double>::max())
                              : TFloat(string_value);
           }
+        catch(std::exception &e)
+          {
+            RUNTIME_ERROR("Json_Number_Parser failed to parse '", string_value,
+                          "': ", e.what());
+          }
         catch(...)
           {
-            El::RuntimeError("Json_Number_Parser failed to parse '",
-                             string_value, "'");
-            return false;
+            RUNTIME_ERROR("Json_Number_Parser failed to parse '", string_value,
+                          "'");
           }
       }
 

--- a/src/sdpb_util/json/Json_Vector_Parser.hxx
+++ b/src/sdpb_util/json/Json_Vector_Parser.hxx
@@ -57,8 +57,8 @@ public:
 
   void on_element_parsed(element_type &&value, size_t index) override
   {
-    if(index != this->result.size())
-      El::LogicError("index=", index, ", expected ", this->result.size());
+    ASSERT(index == this->result.size(), "index=", index, ", expected ",
+           this->result.size());
     this->result.push_back(std::move(value));
   }
 

--- a/src/sdpb_util/json/Vector_Parse_Result_With_Skip.hxx
+++ b/src/sdpb_util/json/Vector_Parse_Result_With_Skip.hxx
@@ -21,8 +21,8 @@ template <class TValue> struct Vector_Parse_Result_With_Skip
   }
   void add_element(TValue &&element, const size_t index)
   {
-    if(index != num_elements)
-      El::LogicError("Expected index=", num_elements, " got ", index);
+    ASSERT(index == num_elements, "Expected index=", num_elements, " got ",
+           index);
 
     parsed_elements.emplace_back(std::forward<TValue>(element));
     indices.emplace_back(index);
@@ -30,8 +30,8 @@ template <class TValue> struct Vector_Parse_Result_With_Skip
   }
   void skip_element(const size_t index)
   {
-    if(index != num_elements)
-      El::LogicError("Expected index=", num_elements, " got ", index);
+    ASSERT(index == num_elements, "Expected index=", num_elements, " got ",
+           index);
     ++num_elements;
   }
 

--- a/src/sdpb_util/write_distmatrix.hxx
+++ b/src/sdpb_util/write_distmatrix.hxx
@@ -2,7 +2,6 @@
 
 #include <El.hpp>
 
-
 inline void write_distmatrix(const El::DistMatrix<El::BigFloat> &matrix,
                              const std::filesystem::path &path)
 {
@@ -19,9 +18,6 @@ inline void write_distmatrix(const El::DistMatrix<El::BigFloat> &matrix,
   if(matrix.DistRank() == matrix.Root())
     {
       stream << "\n";
-      if(!stream.good())
-        {
-          throw std::runtime_error("Error when writing to: " + path.string());
-        }
+      ASSERT(stream.good(), "Error when writing to: ", path);
     }
 }

--- a/src/spectrum/handle_arguments.cxx
+++ b/src/spectrum/handle_arguments.cxx
@@ -1,4 +1,5 @@
 #include "sdpb_util/Boost_Float.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <El.hpp>
 
@@ -69,32 +70,16 @@ void handle_arguments(const int &argc, char **argv, El::BigFloat &threshold,
 
   po::notify(variables_map);
 
-  if(!fs::exists(input_path))
-    {
-      throw std::runtime_error("Input file '" + input_path.string()
-                               + "' does not exist");
-    }
-  if(fs::is_directory(input_path))
-    {
-      throw std::runtime_error("Input file '" + input_path.string()
-                               + "' is a directory, not a file");
-    }
-  if(!fs::exists(solution_dir))
-    {
-      throw std::runtime_error("Solution file '" + solution_dir.string()
-                               + "' does not exist");
-    }
+  ASSERT(fs::exists(input_path), "Input file does not exist: ", input_path);
+  ASSERT(!fs::is_directory(input_path),
+         "Input file is a directory, not a file: ", input_path);
 
-  if(output_path == ".")
-    {
-      throw std::runtime_error("Output file '" + output_path.string()
-                               + "' is a directory");
-    }
-  if(fs::exists(output_path) && fs::is_directory(output_path))
-    {
-      throw std::runtime_error("Output file '" + output_path.string()
-                               + "' exists and is a directory");
-    }
+  ASSERT(fs::exists(solution_dir),
+         "Solution file does not exist: ", solution_dir);
+
+  ASSERT(output_path != ".", "Output file is a directory: ", output_path);
+  ASSERT(!(fs::exists(output_path) && fs::is_directory(output_path)),
+         "Output file exists and is a directory: ", output_path);
 
   El::gmp::SetPrecision(precision);
   // El::gmp wants base-2 bits, but boost::multiprecision wants

--- a/src/spectrum/write_spectrum/write_file.cxx
+++ b/src/spectrum/write_spectrum/write_file.cxx
@@ -1,3 +1,4 @@
+#include "sdpb_util/assert.hxx"
 #include "spectrum/Zeros.hxx"
 #include "sdpb_util/ostream/set_stream_precision.hxx"
 
@@ -12,11 +13,8 @@ void write_file(const fs::path &output_path,
     {
       fs::create_directories(output_path.parent_path());
       std::ofstream outfile(output_path);
-      if(!outfile.good())
-        {
-          throw std::runtime_error("Problem when opening output file: '"
-                                   + output_path.string() + "'");
-        }
+      ASSERT(outfile.good(),
+             "Problem when opening output file: ", output_path);
       set_stream_precision(outfile);
       outfile << "[";
       for(auto zeros_iterator(zeros_blocks.begin());
@@ -56,10 +54,7 @@ void write_file(const fs::path &output_path,
                   << "  }";
         }
       outfile << "\n]\n";
-      if(!outfile.good())
-        {
-          throw std::runtime_error("Problem when writing to output file: '"
-                                   + output_path.string() + "'");
-        }
+      ASSERT(outfile.good(),
+             "Problem when writing to output file: ", output_path);
     }
 }

--- a/src/spectrum/write_spectrum/write_spectrum.cxx
+++ b/src/spectrum/write_spectrum/write_spectrum.cxx
@@ -1,3 +1,4 @@
+#include "sdpb_util/assert.hxx"
 #include "spectrum/Zeros.hxx"
 
 #include <filesystem>
@@ -22,12 +23,10 @@ void write_spectrum(const fs::path &output_path, const size_t &num_blocks,
       std::vector<size_t> zero_sizes(num_blocks, 0),
         lambda_sizes(num_blocks, 0);
 
-      if(block_indices.size() != zeros_blocks.size())
-        {
-          El::RuntimeError("block_indices.size()=", block_indices.size(),
-                           " and zeros_blocks.size()=", zeros_blocks.size(),
-                           " should be equal");
-        }
+      ASSERT(block_indices.size() == zeros_blocks.size(),
+             "block_indices.size()=", block_indices.size(),
+             " and zeros_blocks.size()=", zeros_blocks.size(),
+             " should be equal");
       for(size_t local_index = 0; local_index < block_indices.size();
           ++local_index)
         {

--- a/test/src/integration_tests/main.cxx
+++ b/test/src/integration_tests/main.cxx
@@ -1,4 +1,5 @@
 #include "common.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <filesystem>
 #include <boost/process.hpp>
@@ -29,10 +30,9 @@ namespace
           }
       }
 
-    auto msg = std::string("Cannot find '") + sdp_zip
-               + "'. Please run test executable from root sdpb/ directory "
-                 "or sdpb/build/ directory";
-    throw std::runtime_error(msg);
+    RUNTIME_ERROR("Cannot find '", sdp_zip,
+                  "'. Please run test executable from root sdpb/ directory "
+                  "or sdpb/build/ directory");
   }
 }
 

--- a/test/src/integration_tests/util/Test_Case_Runner.cxx
+++ b/test/src/integration_tests/util/Test_Case_Runner.cxx
@@ -1,5 +1,6 @@
 #include "Test_Case_Runner.hxx"
 #include "Test_Config.hxx"
+#include "sdpb_util/assert.hxx"
 
 #include <fstream>
 
@@ -18,7 +19,10 @@ namespace
   }
 
   // concatenate args with " " separator
-  inline std::string build_args_string(const std::string &arg) { return arg; }
+  inline std::string build_args_string(const std::string &arg)
+  {
+    return arg;
+  }
   template <typename... ArgPack>
   std::string build_args_string(const ArgPack &...args)
   {
@@ -57,7 +61,8 @@ namespace Test_Util
 {
   // NB: name should be a valid path relative to test_log_dir
   Test_Case_Runner::Test_Case_Runner(const std::string &name)
-      : name(name), data_dir(Test_Config::test_data_dir / name),
+      : name(name),
+        data_dir(Test_Config::test_data_dir / name),
         output_dir(Test_Config::test_output_dir / name),
         stdout_path(Test_Config::test_log_dir
                     / fs::path(name + ".stdout.log")),
@@ -67,12 +72,9 @@ namespace Test_Util
     fs::remove_all(Test_Config::test_log_dir / name);
 
     fs::create_directories(stdout_path.parent_path());
-    if(!fs::is_directory(stdout_path.parent_path()))
-      {
-        throw std::runtime_error(
-          stdout_path.parent_path().string()
-          + " is not a directory! Check file name and permissions.");
-      }
+    ASSERT(fs::is_directory(stdout_path.parent_path()),
+           stdout_path.parent_path(),
+           " is not a directory! Check file name and permissions.");
   }
 
   Test_Case_Runner

--- a/wscript
+++ b/wscript
@@ -20,7 +20,7 @@ def configure(conf):
 
 
 def build(bld):
-    default_flags = ['-Wall', '-Wextra', '-O3']
+    default_flags = ['-Wall', '-Wextra', '-Werror=return-type', '-O3']
     default_defines = ['OMPI_SKIP_MPICXX', 'SDPB_VERSION_STRING="' + bld.env.git_version + '"']
     use_packages = ['cxx17', 'gmpxx', 'mpfr', 'boost', 'elemental', 'libxml2', 'rapidjson', 'libarchive', 'sdpb_util']
     default_includes = ['src', 'external']


### PR DESCRIPTION
- Replaced all `throw std::runtime_error()`, `El::RuntimeError()` etc. with `RUNTIME_ERROR()` macro. It throws `std::runtime_error()`, adding current function name, file and line number to the exception message.
- Added `ASSERT()` macro. It checks a condition and throws `RUNTIME_ERROR()` if it fails. This makes code less verbose.
- Added compiler flag `-Werror=return-type`, to fail at "not all code paths return value" etc. It will help to catch errors when return statement is missed by mistake. Previously, I couldn't add it since compiler didn't understand that `El::RuntimeError()` call throws an exception (even with `[[noreturn]]` attribute).