### PR TITLE
Fix #183 pmp2sdp options: --zip flag instead of --zip=(false|true) option

### DIFF
--- a/docs/SDPB_input_format.md
+++ b/docs/SDPB_input_format.md
@@ -6,7 +6,7 @@ with a separate tool, this documents the format you will need to follow.
 
 `pmp2sdp` generates a directory containing multiple
 JSON/binary files.
-It may also generate zip archive instead of a directory, if you run it with option `--zip true`. This can be useful,
+It may also generate zip archive instead of a directory, if you run it with `--zip` flag. This can be useful,
 e.g. to prevent `running out of inodes` error on some filesystems, when SDP contains large number of blocks. Also, the
 zip format has a built-in checksum to detect corruption. Note that `pmp2sdp` does not enable compression, because that
 can be quite slow.

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -255,6 +255,11 @@ unzip -o path/to/sdp.zip -d path/to/sdp_dir
 sdpb -s path/to/sdp_dir <...>
 ```
 
+### 'Running out of inodes' error
+
+This may happen on some filesystems if SDP contains too many block files. Run `pmp2sdp` with `--zip` flag to put
+everything into a single zip archive.
+
 ### Spectrum does not work in parallel
 
 See https://github.com/davidsd/sdpb/issues/152.

--- a/src/pmp/Polynomial_Vector_Matrix.cxx
+++ b/src/pmp/Polynomial_Vector_Matrix.cxx
@@ -70,9 +70,15 @@ namespace
   // We use XXX_or_default() functions instead of std::optional::value_or()
   // to prevent unnecessary computation of default value.
 
+  const Boost_Float exp_minus_one =
+#if(BOOST_VERSION >= 106900)
+    boost::math::constants::exp_minus_one<Boost_Float>();
+#else
+    Boost_Float(1) / boost::math::constants::e<Boost_Float>();
+#endif
+
   // Default prefactor is e^-x
-  const Damped_Rational exp_minus_x
-    = {1, boost::math::constants::exp_minus_one<Boost_Float>(), {}};
+  const Damped_Rational exp_minus_x = {1, exp_minus_one, {}};
 
   Damped_Rational
   prefactor_or_default(const std::optional<Damped_Rational> &prefactor_opt)

--- a/src/pmp2sdp/Pmp2sdp_Parameters/Pmp2sdp_Parameters.cxx
+++ b/src/pmp2sdp/Pmp2sdp_Parameters/Pmp2sdp_Parameters.cxx
@@ -32,7 +32,7 @@ Pmp2sdp_Parameters::Pmp2sdp_Parameters(int argc, char **argv)
       ->default_value(Block_File_Format::bin),
     "Output format for SDP blocks. Could be either 'bin' or 'json'");
   options.add_options()(
-    "zip,z", po::value<bool>(&zip)->default_value(false),
+    "zip,z", po::bool_switch(&zip),
     "Store output to zip file instead of plain directory.");
   options.add_options()(
     "verbosity,v",

--- a/src/pmp2sdp/Pmp2sdp_Parameters/Pmp2sdp_Parameters.hxx
+++ b/src/pmp2sdp/Pmp2sdp_Parameters/Pmp2sdp_Parameters.hxx
@@ -14,7 +14,7 @@ struct Pmp2sdp_Parameters
   std::filesystem::path input_file;
   std::filesystem::path output_path;
   Block_File_Format output_format;
-  bool zip;
+  bool zip = false;
   Verbosity verbosity;
 
   std::vector<std::string> command_arguments;

--- a/src/pmp_read/read_polynomial_matrix_program.cxx
+++ b/src/pmp_read/read_polynomial_matrix_program.cxx
@@ -175,8 +175,8 @@ read_polynomial_matrix_program(const Environment &env,
       }
 
     num_matrices
-      = std::reduce(num_matrices_per_file.begin(), num_matrices_per_file.end(),
-                    static_cast<size_t>(0));
+      = std::accumulate(num_matrices_per_file.begin(),
+                        num_matrices_per_file.end(), static_cast<size_t>(0));
   }
 
   // Get objective, normalization and polynomial vector matrices

--- a/test/src/integration_tests/cases/end-to-end.test.cxx
+++ b/test/src/integration_tests/cases/end-to-end.test.cxx
@@ -38,8 +38,10 @@ namespace
       Test_Util::Test_Case_Runner::Named_Args_Map args{
         {"--input", input.string()},
         {"--output", sdp_path},
-        {"--precision", std::to_string(precision)},
-        {"--zip", std::to_string(zip)}};
+        {"--precision", std::to_string(precision)}};
+
+      if(zip)
+        args["--zip"] = "";
 
       if(!sdp_format.empty())
         args["--outputFormat"] = sdp_format;

--- a/test/src/integration_tests/cases/pmp2sdp.test.cxx
+++ b/test/src/integration_tests/cases/pmp2sdp.test.cxx
@@ -133,8 +133,7 @@ TEST_CASE("pmp2sdp")
       Test_Util::Test_Case_Runner::Named_Args_Map args(default_args);
       args["--input"] = input;
       args["--output"] = sdp_dir.string();
-      runner.mpi_run({"build/pmp2sdp"}, args, num_procs, 1,
-                     "Directory not empty");
+      runner.mpi_run({"build/pmp2sdp"}, args, num_procs, 1, "cannot rename");
     }
 
     SECTION("cannot_write_zip")

--- a/test/src/integration_tests/cases/pmp2sdp.test.cxx
+++ b/test/src/integration_tests/cases/pmp2sdp.test.cxx
@@ -152,7 +152,7 @@ TEST_CASE("pmp2sdp")
       Test_Util::Test_Case_Runner::Named_Args_Map args(default_args);
       args["--input"] = input;
       args["--output"] = sdp_readonly_zip.string();
-      args["--zip"] = "true";
+      args["--zip"] = "";
       runner.mpi_run({"build/pmp2sdp"}, args, num_procs, 1,
                      "Unable to set options for writing an archive");
     }


### PR DESCRIPTION
- #183 
- fix compilation and `integration_tests` errors on different configurations