### PR TITLE
Add -fsanitize=undefined flag for compiler and linker

### DIFF
--- a/waf-tools/fsanitize.py
+++ b/waf-tools/fsanitize.py
@@ -1,0 +1,19 @@
+#! /usr/bin/env python
+# encoding: utf-8
+
+# -fsanitize=undefined checks for undefined behaviour in runtime
+# This could prevent some weird UB errors, e.g. caused by -O3 compiler optimizations.
+def configure(conf):
+    cxx_fragment = '''
+    int main() {
+        int x = 1;
+        return 0;
+    }
+    '''
+    flag = '-fsanitize=undefined'
+    try:
+        conf.check_cxx(msg=f'Checking for {flag}',
+                       fragment=cxx_fragment,
+                       cxxflags=flag, linkflags=flag, uselib_store='fsanitize')
+    except conf.errors.ConfigurationError as e:
+        conf.to_log(f'{flag} not supported')

--- a/wscript
+++ b/wscript
@@ -20,7 +20,8 @@ def configure(conf):
 
 
 def build(bld):
-    default_flags = ['-Wall', '-Wextra', '-Werror=return-type', '-O3']
+    default_flags = ['-Wall', '-Wextra', '-Werror=return-type', '-O3', '-fsanitize=undefined']
+    default_linkflags = ['-fsanitize=undefined']
     default_defines = ['OMPI_SKIP_MPICXX', 'SDPB_VERSION_STRING="' + bld.env.git_version + '"']
     use_packages = ['cxx17', 'gmpxx', 'mpfr', 'boost', 'elemental', 'libxml2', 'rapidjson', 'libarchive', 'sdpb_util']
     default_includes = ['src', 'external']
@@ -34,6 +35,7 @@ def build(bld):
                       'src/sdpb_util/Timers/Timers.cxx'],
               target='sdpb_util',
               cxxflags=default_flags,
+              linkflags=default_linkflags,
               defines=default_defines,
               includes=default_includes,
               use=['cxx17', 'gmpxx', 'boost', 'elemental'])
@@ -98,6 +100,7 @@ def build(bld):
     bld.stlib(source=sdp_solve_sources,
               target='sdp_solve',
               cxxflags=default_flags,
+              linkflags=default_linkflags,
               defines=default_defines,
               includes=default_includes,
               use=use_packages + ['pmp2sdp_lib'])
@@ -112,6 +115,7 @@ def build(bld):
                         'src/sdpb/save_solution.cxx'],
                 target='sdpb',
                 cxxflags=default_flags,
+                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['sdp_solve']
@@ -134,6 +138,7 @@ def build(bld):
     bld.stlib(source=pmp2sdp_sources,
               target='pmp2sdp_lib',
               cxxflags=default_flags,
+              linkflags=default_linkflags,
               defines=default_defines,
               includes=default_includes,
               use=use_packages + ['pmp'])
@@ -142,6 +147,7 @@ def build(bld):
                         'src/pvm2sdp/parse_command_line.cxx'],
                 target='pvm2sdp',
                 cxxflags=default_flags,
+                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp_read']
@@ -162,6 +168,7 @@ def build(bld):
     bld.stlib(source=pmp_sources,
               target='pmp',
               cxxflags=default_flags,
+              linkflags=default_linkflags,
               defines=default_defines,
               includes=default_includes,
               use=use_packages)
@@ -188,6 +195,7 @@ def build(bld):
     bld.stlib(source=pmp_read_sources,
               target='pmp_read',
               cxxflags=default_flags,
+              linkflags=default_linkflags,
               defines=default_defines,
               includes=default_includes,
               use=use_packages + ['pmp', 'pmp2sdp_lib'])
@@ -195,6 +203,7 @@ def build(bld):
     bld.program(source=['src/sdp2input/main.cxx'],
                 target='sdp2input',
                 cxxflags=default_flags,
+                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp', 'pmp_read', 'pmp2sdp_lib']
@@ -205,6 +214,7 @@ def build(bld):
                         ],
                 target='pmp2sdp',
                 cxxflags=default_flags,
+                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp', 'pmp_read', 'pmp2sdp_lib']
@@ -236,6 +246,7 @@ def build(bld):
                         ],
                 target='outer_limits',
                 cxxflags=default_flags,
+                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp_read', 'sdp_solve', 'mesh']
@@ -254,6 +265,7 @@ def build(bld):
                         ],
                 target='approx_objective',
                 cxxflags=default_flags,
+                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp_read', 'sdp_solve']
@@ -264,6 +276,7 @@ def build(bld):
                         'src/pmp2functions/write_functions.cxx'],
                 target='pmp2functions',
                 cxxflags=default_flags,
+                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp_read']
@@ -280,6 +293,7 @@ def build(bld):
                         'src/spectrum/write_spectrum/write_file.cxx'],
                 target='spectrum',
                 cxxflags=default_flags,
+                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp_read', 'sdp_solve', 'pmp2sdp_lib', 'mesh']
@@ -301,6 +315,7 @@ def build(bld):
                 target='integration_tests',
                 install_path=None,
                 cxxflags=default_flags,
+                linkflags=default_linkflags,
                 defines=default_defines + ['CATCH_AMALGAMATED_CUSTOM_MAIN'],
                 use=use_packages,
                 includes=default_includes + ['test/src']
@@ -316,6 +331,7 @@ def build(bld):
                         'test/src/unit_tests/cases/shared_window.test.cxx'],
                 target='unit_tests',
                 cxxflags=default_flags,
+                linkflags=default_linkflags,
                 defines=default_defines + ['CATCH_AMALGAMATED_CUSTOM_MAIN'],
                 use=use_packages + ['pmp_read', 'pmp2sdp_lib', 'sdp_solve'],
                 includes=default_includes + ['test/src']

--- a/wscript
+++ b/wscript
@@ -14,16 +14,17 @@ def configure(conf):
     conf.load(['compiler_cxx', 'gnu_dirs', 'cxx17', 'boost', 'gmpxx', 'mpfr',
                'elemental', 'libxml2', 'rapidjson', 'libarchive'])
     conf.load('clang_compilation_database', tooldir='./waf-tools')
+    conf.load('fsanitize', tooldir='./waf-tools')
 
     conf.env.git_version = subprocess.check_output('git describe --tags --always --dirty', universal_newlines=True,
                                                    shell=True).rstrip()
 
 
 def build(bld):
-    default_flags = ['-Wall', '-Wextra', '-Werror=return-type', '-O3', '-fsanitize=undefined']
-    default_linkflags = ['-fsanitize=undefined']
+    default_flags = ['-Wall', '-Wextra', '-Werror=return-type', '-O3']
     default_defines = ['OMPI_SKIP_MPICXX', 'SDPB_VERSION_STRING="' + bld.env.git_version + '"']
-    use_packages = ['cxx17', 'gmpxx', 'mpfr', 'boost', 'elemental', 'libxml2', 'rapidjson', 'libarchive', 'sdpb_util']
+    use_packages = ['cxx17', 'fsanitize', 'gmpxx', 'mpfr', 'boost', 'elemental', 'libxml2', 'rapidjson', 'libarchive',
+                    'sdpb_util']
     default_includes = ['src', 'external']
 
     bld.stlib(source=['src/sdpb_util/copy_matrix.cxx',
@@ -35,10 +36,9 @@ def build(bld):
                       'src/sdpb_util/Timers/Timers.cxx'],
               target='sdpb_util',
               cxxflags=default_flags,
-              linkflags=default_linkflags,
               defines=default_defines,
               includes=default_includes,
-              use=['cxx17', 'gmpxx', 'boost', 'elemental'])
+              use=['cxx17', 'fsanitize', 'gmpxx', 'boost', 'elemental'])
 
     sdp_solve_sources = ['src/sdp_solve/Solver_Parameters/Solver_Parameters.cxx',
                          'src/sdp_solve/Solver_Parameters/ostream.cxx',
@@ -100,7 +100,6 @@ def build(bld):
     bld.stlib(source=sdp_solve_sources,
               target='sdp_solve',
               cxxflags=default_flags,
-              linkflags=default_linkflags,
               defines=default_defines,
               includes=default_includes,
               use=use_packages + ['pmp2sdp_lib'])
@@ -115,7 +114,6 @@ def build(bld):
                         'src/sdpb/save_solution.cxx'],
                 target='sdpb',
                 cxxflags=default_flags,
-                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['sdp_solve']
@@ -138,7 +136,6 @@ def build(bld):
     bld.stlib(source=pmp2sdp_sources,
               target='pmp2sdp_lib',
               cxxflags=default_flags,
-              linkflags=default_linkflags,
               defines=default_defines,
               includes=default_includes,
               use=use_packages + ['pmp'])
@@ -147,7 +144,6 @@ def build(bld):
                         'src/pvm2sdp/parse_command_line.cxx'],
                 target='pvm2sdp',
                 cxxflags=default_flags,
-                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp_read']
@@ -168,7 +164,6 @@ def build(bld):
     bld.stlib(source=pmp_sources,
               target='pmp',
               cxxflags=default_flags,
-              linkflags=default_linkflags,
               defines=default_defines,
               includes=default_includes,
               use=use_packages)
@@ -195,7 +190,6 @@ def build(bld):
     bld.stlib(source=pmp_read_sources,
               target='pmp_read',
               cxxflags=default_flags,
-              linkflags=default_linkflags,
               defines=default_defines,
               includes=default_includes,
               use=use_packages + ['pmp', 'pmp2sdp_lib'])
@@ -203,7 +197,6 @@ def build(bld):
     bld.program(source=['src/sdp2input/main.cxx'],
                 target='sdp2input',
                 cxxflags=default_flags,
-                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp', 'pmp_read', 'pmp2sdp_lib']
@@ -214,7 +207,6 @@ def build(bld):
                         ],
                 target='pmp2sdp',
                 cxxflags=default_flags,
-                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp', 'pmp_read', 'pmp2sdp_lib']
@@ -246,7 +238,6 @@ def build(bld):
                         ],
                 target='outer_limits',
                 cxxflags=default_flags,
-                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp_read', 'sdp_solve', 'mesh']
@@ -265,7 +256,6 @@ def build(bld):
                         ],
                 target='approx_objective',
                 cxxflags=default_flags,
-                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp_read', 'sdp_solve']
@@ -276,7 +266,6 @@ def build(bld):
                         'src/pmp2functions/write_functions.cxx'],
                 target='pmp2functions',
                 cxxflags=default_flags,
-                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp_read']
@@ -293,7 +282,6 @@ def build(bld):
                         'src/spectrum/write_spectrum/write_file.cxx'],
                 target='spectrum',
                 cxxflags=default_flags,
-                linkflags=default_linkflags,
                 defines=default_defines,
                 includes=default_includes,
                 use=use_packages + ['pmp_read', 'sdp_solve', 'pmp2sdp_lib', 'mesh']
@@ -315,7 +303,6 @@ def build(bld):
                 target='integration_tests',
                 install_path=None,
                 cxxflags=default_flags,
-                linkflags=default_linkflags,
                 defines=default_defines + ['CATCH_AMALGAMATED_CUSTOM_MAIN'],
                 use=use_packages,
                 includes=default_includes + ['test/src']
@@ -331,7 +318,6 @@ def build(bld):
                         'test/src/unit_tests/cases/shared_window.test.cxx'],
                 target='unit_tests',
                 cxxflags=default_flags,
-                linkflags=default_linkflags,
                 defines=default_defines + ['CATCH_AMALGAMATED_CUSTOM_MAIN'],
                 use=use_packages + ['pmp_read', 'pmp2sdp_lib', 'sdp_solve'],
                 includes=default_includes + ['test/src']


### PR DESCRIPTION
With this flag, undefined behaviour is detected at runtime, see https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fsanitize_003dundefined

This apparently fixes weird SEGFAULT occurring in `bilinear_form()` in pmp2sdp (for some JSON files generated by from stress-tensors-3d).

Segfault occurred only when compiled with `-O3`.
What's even more interesting, segfault disappeared in the following cases:
- if I add El::Output() anywhere inside `bilinear_form()` code,
- when compiled with `-O2` instead of `-O3`
- on recent [ba49cd3bf90094308e7b31c7141a28674235edb2](https://github.com/davidsd/sdpb/commit/ba49cd3bf90094308e7b31c7141a28674235edb2), although nothing changed in bilinear_bases code since then.
- when compiled with `-O3 -fsanitize=undefined` 

Probably `-fsanitize=undefined` prevents compiler from some incorrect optimizations introducing undefined behaviour.
I didn't spot any undefined behaviour in our code:
https://github.com/davidsd/sdpb/blob/06db88dc8dc5f5a18416e295f56c125fb8225cbf/src/pmp/convert/bilinear_basis/bilinear_form/bilinear_form.cxx

P.S. I also checked that `-fsanitize=undefined` does not affect SDPB performance.