### PR TITLE
Fix #115 Print exception stacktrace when SDPB fails

### DIFF
--- a/src/sdpb_util/assert.hxx
+++ b/src/sdpb_util/assert.hxx
@@ -2,14 +2,20 @@
 
 #include <El.hpp>
 
+#include <boost/stacktrace.hpp>
+
 #include <exception>
 
+// Throw exception with source code location, message and stacktrace.
+// NB: ideally, stacktrace should contain source code location for each frame,
+// but that depends on Boost.Stacktrace configuration.
+// Thus, we print location explicitly.
 #define THROW(exception_type, ...)                                            \
   do                                                                          \
     {                                                                         \
-      throw exception_type(El::BuildString("in ", __FUNCTION__, "() at ",     \
-                                           __FILE__, ":", __LINE__, ": \n  ", \
-                                           __VA_ARGS__));                     \
+      throw exception_type(El::BuildString(                                   \
+        "in ", __FUNCTION__, "() at ", __FILE__, ":", __LINE__, ": \n  ",     \
+        __VA_ARGS__, "\nStacktrace:\n", boost::stacktrace::stacktrace()));    \
   } while(false)
 
 #define RUNTIME_ERROR(...) THROW(std::runtime_error, __VA_ARGS__)

--- a/waf-tools/boost.py
+++ b/waf-tools/boost.py
@@ -5,43 +5,43 @@ def configure(conf):
     # Find Boost
     import os
     if not conf.options.boost_incdir and not conf.options.boost_dir:
-        for d in ['BOOST_INCLUDE','BOOST_INCLUDE_DIR','BOOST_INC_DIR']:
-            env_dir=os.getenv(d)
+        for d in ['BOOST_INCLUDE', 'BOOST_INCLUDE_DIR', 'BOOST_INC_DIR']:
+            env_dir = os.getenv(d)
             if env_dir:
                 conf.to_log('Setting boost_incdir using environment variable: ' + d + '=' + env_dir)
-                conf.options.boost_incdir=env_dir
-                
+                conf.options.boost_incdir = env_dir
+
     if not conf.options.boost_libdir and not conf.options.boost_dir:
-        for d in ['BOOST_LIB','BOOST_LIB_DIR']:
-            env_dir=os.getenv(d)
+        for d in ['BOOST_LIB', 'BOOST_LIB_DIR']:
+            env_dir = os.getenv(d)
             if env_dir:
                 conf.to_log('Setting boost_libdir using environment variable: ' + d + '=' + env_dir)
-                conf.options.boost_libdir=env_dir
+                conf.options.boost_libdir = env_dir
 
     if not conf.options.boost_dir:
-        for d in ['BOOST_HOME','BOOST_DIR']:
-            env_dir=os.getenv(d)
+        for d in ['BOOST_HOME', 'BOOST_DIR']:
+            env_dir = os.getenv(d)
             if env_dir:
                 conf.to_log('Setting boost_dir using environment variable: ' + d + '=' + env_dir)
-                conf.options.boost_dir=env_dir
-                
+                conf.options.boost_dir = env_dir
+
     if conf.options.boost_dir:
         if not conf.options.boost_incdir:
-            conf.options.boost_incdir=conf.options.boost_dir + "/include"
+            conf.options.boost_incdir = conf.options.boost_dir + "/include"
         if not conf.options.boost_libdir:
-            conf.options.boost_libdir=conf.options.boost_dir + "/lib"
+            conf.options.boost_libdir = conf.options.boost_dir + "/lib"
 
     if conf.options.boost_incdir:
-        boost_incdir=conf.options.boost_incdir.split()
+        boost_incdir = conf.options.boost_incdir.split()
     else:
-        boost_incdir=[]
+        boost_incdir = []
     if conf.options.boost_libdir:
-        boost_libdir=conf.options.boost_libdir.split()
+        boost_libdir = conf.options.boost_libdir.split()
     else:
-        boost_libdir=[]
+        boost_libdir = []
 
     if conf.options.boost_libs:
-        boost_libs=conf.options.boost_libs.split()
+        boost_libs = conf.options.boost_libs.split()
     else:
         boost_libs = ['boost_system', 'boost_date_time', 'boost_filesystem',
                       'boost_program_options', 'boost_iostreams', 'boost_serialization']
@@ -107,15 +107,14 @@ boost::stacktrace::stacktrace();
                 break
 
 
-
 def options(opt):
-    boost=opt.add_option_group('Boost Options')
+    boost = opt.add_option_group('Boost Options')
     boost.add_option('--boost-dir',
-                   help='Base directory where boost is installed')
+                     help='Base directory where boost is installed')
     boost.add_option('--boost-incdir',
-                   help='Directory where boost include files are installed')
+                     help='Directory where boost include files are installed')
     boost.add_option('--boost-libdir',
-                   help='Directory where boost library files are installed')
+                     help='Directory where boost library files are installed')
     boost.add_option('--boost-libs',
-                   help='Names of the boost libraries without prefix or suffix\n'
-                        '(e.g. "boost_system boost_date_time boost_program_options")')
+                     help='Names of the boost libraries without prefix or suffix\n'
+                          '(e.g. "boost_system boost_date_time boost_program_options")')

--- a/wscript
+++ b/wscript
@@ -20,7 +20,7 @@ def configure(conf):
 
 
 def build(bld):
-    default_flags = ['-Wall', '-Wextra', '-Werror=return-type', '-O3']
+    default_flags = ['-Wall', '-Wextra', '-Werror=return-type', '-O3', '-g']
     default_defines = ['OMPI_SKIP_MPICXX', 'SDPB_VERSION_STRING="' + bld.env.git_version + '"']
     use_packages = ['cxx17', 'gmpxx', 'mpfr', 'boost', 'elemental', 'libxml2', 'rapidjson', 'libarchive', 'sdpb_util']
     default_includes = ['src', 'external']


### PR DESCRIPTION
Fix #115

We [use](https://github.com/davidsd/sdpb/blob/18456f51d280a942b31cebbf4f45274d56c324e7/src/sdpb_util/assert.hxx#L18) `boost::stacktrace::stacktrace()` in `THROW()` macro, so that we get stacktrace for all exceptions in our code. Note that we cannot simply get a stacktrace for a third-party exception (e.g. thrown by Elemental).

Example:
```
$ ./build/sdpb --sdpDir someMissingPath
Process 0 caught error message:
in SDPB_Parameters() at ../src/sdpb/SDPB_Parameters/SDPB_Parameters.cxx:11:
  Assertion 'false' failed:

Stacktrace:
 0# SDPB_Parameters::SDPB_Parameters(int, char**) at ../src/sdpb/SDPB_Parameters/SDPB_Parameters.cxx:11
 1# main at ../src/sdpb/main.cxx:32
 2# __libc_start_call_main at ../sysdeps/nptl/libc_start_call_main.h:58
 3# __libc_start_main at ../csu/libc-start.c:379
 4# _start in ./build/sdpb

```

I added debug symbols to executable by enabled the compilation flag '-g'.

Pros:
- we can get source location from stacktraces and core dumps. Note that we cannot simply print stacktrace e.g. for SEGFAULT, but we can get it later from core dump.

Cons:
- Compilation is ~2x slower (~11.5min vs ~6.5min on CircleCI).
- Executable files are larger: sdpb grows from 1.2MB to 29.2MB. Docker image now takes ~600MB instead of ~160MB (because of debug symbols and because of adding `boost-dev` package). Note that it doesn't affect runtime performance or memory footprint.


When configuring, we try to link `boost_stacktrace_backtrace`, `boost_stacktrace_addr2line` or `boost_stacktrace_basic`. The first two options allow to print source code location for each frame. If linking fails, we use Boost.Stacktrace as a header-only library.
See details in https://www.boost.org/doc/libs/1_84_0/doc/html/stacktrace/configuration_and_build.html

TODO: Docker image uses `boost_stacktrace_addr2line`, but for some reason fails to print source code locations:
```
$ docker run sdpb /usr/local/bin/sdpb --sdpDir someMissingPath
Process 0 caught error message:
in SDPB_Parameters() at ../src/sdpb/SDPB_Parameters/SDPB_Parameters.cxx:115:
  Assertion 'fs::exists(sdp_path)' failed:
    sdp directory does not exist:"someMissingPath"
Stacktrace:
 0# 0x0000556D67FBB3CE in /usr/local/bin/sdpb
 1# 0x0000556D67FD2942 in /usr/local/bin/sdpb
 2# 0x00007FB77AAF6AAD in /lib/ld-musl-x86_64.so.1

$ docker run sdpb addr2line -e /usr/local/bin/sdpb 0x000055A0484E13CE
??:0
```