### PR TITLE
Fix #201 Graceful exit on SIGTERM + cosmetic fixes

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -266,13 +266,6 @@ sdpb -s path/to/sdp_dir <...>
 This may happen on some filesystems if SDP contains too many block files. Run `pmp2sdp` with `--zip` flag to put
 everything into a single zip archive.
 
-### Spectrum does not work in parallel
-
-See https://github.com/davidsd/sdpb/issues/152.
-
-If this happens, replace, e.g. `mpirun -n 6  build/spectrum <...>` with `mpirun -n 1  build/spectrum <...>` or
-simply `build/spectrum <...>`.
-
 ### Spectrum does not find zeros
 
 Try to set `--threshold` option for `spectrum` larger than `--dualityGapThreshold` for `sdpb`.

--- a/src/outer_limits/compute_optimal/compute_optimal.cxx
+++ b/src/outer_limits/compute_optimal/compute_optimal.cxx
@@ -209,7 +209,7 @@ std::vector<El::BigFloat> compute_optimal(
 
           Timers timers(env, parameters.verbosity >= Verbosity::debug);
           SDP_Solver_Terminate_Reason reason = solver.run(
-            parameters.solver, parameters.verbosity, parameter_properties,
+            env, parameters.solver, parameters.verbosity, parameter_properties,
             block_info, sdp, grid, start_time, timers);
 
           for(size_t index(0); index < block_info.block_indices.size();
@@ -274,7 +274,8 @@ std::vector<El::BigFloat> compute_optimal(
              || reason == SDP_Solver_Terminate_Reason::MaxIterationsExceeded
              || reason == SDP_Solver_Terminate_Reason::MaxRuntimeExceeded
              || reason == SDP_Solver_Terminate_Reason::PrimalStepTooSmall
-             || reason == SDP_Solver_Terminate_Reason::DualStepTooSmall)
+             || reason == SDP_Solver_Terminate_Reason::DualStepTooSmall
+             || reason == SDP_Solver_Terminate_Reason::SIGTERM_Received)
             {
               RUNTIME_ERROR("Cannot find solution: ", reason);
             }

--- a/src/sdp_solve/SDP_Solver.hxx
+++ b/src/sdp_solve/SDP_Solver.hxx
@@ -81,7 +81,8 @@ public:
              const size_t &dual_objective_b_height);
 
   SDP_Solver_Terminate_Reason
-  run(const Solver_Parameters &parameters, const Verbosity &verbosity,
+  run(const Environment &env, const Solver_Parameters &parameters,
+      const Verbosity &verbosity,
       const boost::property_tree::ptree &parameter_properties,
       const Block_Info &block_info, const SDP &sdp, const El::Grid &grid,
       const std::chrono::time_point<std::chrono::high_resolution_clock>

--- a/src/sdp_solve/SDP_Solver_Terminate_Reason.hxx
+++ b/src/sdp_solve/SDP_Solver_Terminate_Reason.hxx
@@ -17,6 +17,7 @@ enum class SDP_Solver_Terminate_Reason
   MaxRuntimeExceeded,
   PrimalStepTooSmall,
   DualStepTooSmall,
+  SIGTERM_Received,
 };
 
 std::ostream &

--- a/src/sdp_solve/SDP_Solver_Terminate_Reason/ostream.cxx
+++ b/src/sdp_solve/SDP_Solver_Terminate_Reason/ostream.cxx
@@ -1,4 +1,5 @@
 #include "../SDP_Solver_Terminate_Reason.hxx"
+#include "sdpb_util/assert.hxx"
 
 std::ostream &
 operator<<(std::ostream &os, const SDP_Solver_Terminate_Reason &r)
@@ -35,6 +36,10 @@ operator<<(std::ostream &os, const SDP_Solver_Terminate_Reason &r)
     case SDP_Solver_Terminate_Reason::DualStepTooSmall:
       os << "dual step too small";
       break;
+    case SDP_Solver_Terminate_Reason::SIGTERM_Received:
+      os << "SIGTERM signal received";
+      break;
+    default: RUNTIME_ERROR("Unknown SDP_Solver_Terminate_Reason=", r);
     }
   return os;
 }

--- a/src/sdpb/solve.cxx
+++ b/src/sdpb/solve.cxx
@@ -3,6 +3,8 @@
 #include "sdpb_util/ostream/set_stream_precision.hxx"
 
 #include <El.hpp>
+#include <csignal>
+#include <cstdlib>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <filesystem>
 
@@ -45,7 +47,7 @@ Timers solve(const Block_Info &block_info, const SDPB_Parameters &parameters,
   const boost::property_tree::ptree parameters_tree(
     to_property_tree(parameters));
   SDP_Solver_Terminate_Reason reason(
-    solver.run(parameters.solver, parameters.verbosity, parameters_tree,
+    solver.run(env, parameters.solver, parameters.verbosity, parameters_tree,
                block_info, sdp, grid, start_time, timers));
 
   if(parameters.verbosity >= Verbosity::regular && El::mpi::Rank() == 0)
@@ -61,7 +63,8 @@ Timers solve(const Block_Info &block_info, const SDPB_Parameters &parameters,
                 << '\n';
     }
 
-  if(!parameters.no_final_checkpoint)
+  if(reason == SDP_Solver_Terminate_Reason::SIGTERM_Received
+     || !parameters.no_final_checkpoint)
     {
       solver.save_checkpoint(parameters.solver.checkpoint_out,
                              parameters.verbosity, parameters_tree);
@@ -73,5 +76,13 @@ Timers solve(const Block_Info &block_info, const SDPB_Parameters &parameters,
   save_solution(solver, reason, runtime, parameters.out_directory,
                 parameters.write_solution, block_info.block_indices,
                 sdp.normalization, parameters.verbosity);
+
+  if(reason == SDP_Solver_Terminate_Reason::SIGTERM_Received)
+    {
+      if(El::mpi::Rank() == 0)
+        El::Output("Received SIGTERM, exiting gracefully...");
+      MPI_Finalize();
+      std::exit(SIGTERM);
+    }
   return timers;
 }

--- a/src/sdpb_util/Environment.hxx
+++ b/src/sdpb_util/Environment.hxx
@@ -17,6 +17,8 @@ struct Environment
   // Node index for current rank, 0..(num_nodes-1)
   [[nodiscard]] int node_index() const;
 
+  [[nodiscard]] bool sigterm_received() const;
+
 private:
   El::Environment env;
   int _num_nodes = -1;

--- a/src/sdpb_util/assert.hxx
+++ b/src/sdpb_util/assert.hxx
@@ -43,7 +43,7 @@
 // int y = 2;
 // ASSERT_EQUAL(x,y) // Assertion 'x == y' failed: x='1' x='2'
 #define ASSERT_EQUAL(a, b, ...)                                               \
-  ASSERT(a == b, DEBUG_STRING(a), "\n    ", DEBUG_STRING(b), "\n    ",        \
+  ASSERT((a) == (b), DEBUG_STRING(a), "\n    ", DEBUG_STRING(b), "\n    ",    \
          El::BuildString(__VA_ARGS__))
 
 #define PRINT_WARNING(...)                                                    \

--- a/src/sdpb_util/assert.hxx
+++ b/src/sdpb_util/assert.hxx
@@ -33,10 +33,10 @@
 
 // Example:
 // int x = 1;
-// auto s = DEBUG_STRING(x+x) // s = "x+x=='2' "
-// Trailing whitespace added for convenience
-// in cases like ASSERT(false, DEBUG_STRING(a), DEBUG_STRING(b))
-#define DEBUG_STRING(expr) El::BuildString(#expr, "='", expr, "' ")
+// auto s = DEBUG_STRING(x+x) // s = " x+x=='2' "
+// Leading and trailing whitespaces added for convenience
+// in cases like ASSERT(false, "message", DEBUG_STRING(a), DEBUG_STRING(b))
+#define DEBUG_STRING(expr) El::BuildString(" ", #expr, "='", expr, "' ")
 
 // Example:
 // int x = 1;

--- a/src/spectrum/compute_spectrum.cxx
+++ b/src/spectrum/compute_spectrum.cxx
@@ -15,8 +15,6 @@ compute_spectrum(const Polynomial_Matrix_Program &pmp,
 {
   std::vector<El::BigFloat> normalization;
   if(pmp.normalization.has_value())
-    normalization = pmp.normalization.value();
-  if(pmp.normalization.has_value())
     {
       normalization = pmp.normalization.value();
     }


### PR DESCRIPTION
- #201 
At start of each iteration, SDPB checks for SIGTERM signal. If signal is caught, SDPB saves checkpoint, prints message and exits with code=15 (=SIGTERM).
- Some cosmetic updates