### PR TITLE
Minor memory-related fixes and improvements: pretty-print bytes, 

### DIFF
--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/BigInt_Shared_Memory_Syrk_Context.cxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/BigInt_Shared_Memory_Syrk_Context.cxx
@@ -280,12 +280,12 @@ BigInt_Shared_Memory_Syrk_Context::BigInt_Shared_Memory_Syrk_Context(
     }
 
   output_residues_window = std::make_unique<Residue_Matrices_Window<double>>(
-    shared_memory_comm, comb.num_primes, window_width, window_width, debug);
+    shared_memory_comm, comb.num_primes, window_width, window_width);
 
   input_grouped_block_residues_window_A
     = std::make_unique<Block_Residue_Matrices_Window<double>>(
       shared_memory_comm, comb.num_primes, num_groups,
-      input_window_height_per_group_per_prime, window_width, debug);
+      input_window_height_per_group_per_prime, window_width);
 
   // We need a second input window only to calculate off-diagonal blocks
   // of the output window.
@@ -294,7 +294,7 @@ BigInt_Shared_Memory_Syrk_Context::BigInt_Shared_Memory_Syrk_Context(
       input_grouped_block_residues_window_B
         = std::make_unique<Block_Residue_Matrices_Window<double>>(
           shared_memory_comm, comb.num_primes, num_groups,
-          input_window_height_per_group_per_prime, window_width, debug);
+          input_window_height_per_group_per_prime, window_width);
     }
 
   {

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/BigInt_Shared_Memory_Syrk_Context.cxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/BigInt_Shared_Memory_Syrk_Context.cxx
@@ -1,6 +1,8 @@
 #include "../BigInt_Shared_Memory_Syrk_Context.hxx"
 #include "../fmpz/fmpz_mul_blas_util.hxx"
 #include "sdpb_util/assert.hxx"
+#include "sdpb_util/ostream/ostream_vector.hxx"
+#include "sdpb_util/ostream/pretty_print_bytes.hxx"
 
 #include <El.hpp>
 
@@ -153,10 +155,14 @@ BigInt_Shared_Memory_Syrk_Context::BigInt_Shared_Memory_Syrk_Context(
           RUNTIME_ERROR(
             "Cannot allocate shared memory window for input block residues."
             " Required: at least ",
-            residues_bytes_per_single_block_row,
-            " bytes per each MPI group, available: ", max_input_window_bytes,
-            " bytes in total. ", DEBUG_STRING(max_shared_memory_bytes),
-            DEBUG_STRING(output_window_bytes), DEBUG_STRING(num_groups));
+            pretty_print_bytes(residues_bytes_per_single_block_row, true),
+            " per each MPI group, available: ",
+            pretty_print_bytes(max_input_window_bytes), " in total. ",
+            "\n\tmax_shared_memory = ",
+            pretty_print_bytes(max_shared_memory_bytes, true),
+            "\n\toutput_window = ",
+            pretty_print_bytes(output_window_bytes, true), "\n\t",
+            DEBUG_STRING(num_groups));
         }
     }
 
@@ -189,14 +195,27 @@ BigInt_Shared_Memory_Syrk_Context::BigInt_Shared_Memory_Syrk_Context(
           El::BuildStream(
             ss,
             "\tConsider increasing available shared memory per node "
-            "(--maxSharedMemory option).\n",
-            "\tShared memory limit: ", max_shared_memory_bytes, " bytes.\n",
-            "\tOutput window size (without splitting): ",
-            window_size_bytes(block_width, block_width, comb.num_primes),
-            " bytes.\n", "\tInput window size (without splitting): ",
-            window_size_bytes(total_block_height_per_node, block_width,
-                              comb.num_primes),
-            " bytes.\n");
+            "(--maxSharedMemory option).",
+            "\n\tShared memory limit: ",
+            pretty_print_bytes(max_shared_memory_bytes, true),
+            "\n\tOutput window:", "\n\t\tactual size after splitting: ",
+            pretty_print_bytes(
+              window_size_bytes(window_width, window_width, comb.num_primes),
+              true),
+            "\n\t\toptimal size without splitting: ",
+            pretty_print_bytes(
+              window_size_bytes(block_width, block_width, comb.num_primes),
+              true),
+            "\n\tInput window:"
+            "\n\t\tactual size after splitting: ",
+            pretty_print_bytes(
+              window_size_bytes(sum(input_window_height_per_group_per_prime),
+                                window_width, comb.num_primes),
+              true),
+            "\n\t\toptimal size without splitting: ",
+            pretty_print_bytes(window_size_bytes(total_block_height_per_node,
+                                                 block_width, comb.num_primes),
+                               true));
           PRINT_WARNING(ss.str());
         }
     }
@@ -207,8 +226,8 @@ BigInt_Shared_Memory_Syrk_Context::BigInt_Shared_Memory_Syrk_Context(
       std::ostringstream os;
       El::BuildStream(os, "create BigInt_Shared_Memory_Syrk_Context, rank=",
                       El::mpi::Rank(), "\n");
-      El::BuildStream(
-        os, "  Shared memory limit, bytes: ", max_shared_memory_bytes, "\n");
+      El::BuildStream(os, "  Shared memory limit: ",
+                      pretty_print_bytes(max_shared_memory_bytes, true), "\n");
       El::BuildStream(os, "  Number of primes: ", comb.num_primes, "\n");
 
       El::BuildStream(os, "  Blocks on the node:\n");
@@ -218,14 +237,18 @@ BigInt_Shared_Memory_Syrk_Context::BigInt_Shared_Memory_Syrk_Context(
       El::BuildStream(os, "    Width: ", block_width, "\n");
       El::BuildStream(
         os, "    Elements: ", total_block_height_per_node * block_width, "\n");
-      El::Print(blocks_height_per_group,
-                "    Heights for each MPI group:", ", ", os);
-      os << "\n";
+      // TODO for some reason, El::BuildStream() fails for std::vector
+      // although we've included sdpb_util/ostream/ostream_vector.hxx
+      os << "    Heights for each MPI group: " << blocks_height_per_group
+         << "\n";
 
       El::BuildStream(os, "  Output residues window (Q):\n");
       El::BuildStream(
-        os, "    Window size, bytes: ",
-        window_size_bytes(window_width, window_width, comb.num_primes), "\n");
+        os, "    Window size: ",
+        pretty_print_bytes(
+          window_size_bytes(window_width, window_width, comb.num_primes),
+          true),
+        "\n");
       El::BuildStream(os, "    Split factor: ", output_window_split_factor,
                       "\n");
       El::BuildStream(os, "    Height=Width (per prime): ", window_width,
@@ -236,22 +259,22 @@ BigInt_Shared_Memory_Syrk_Context::BigInt_Shared_Memory_Syrk_Context(
       auto input_window_height = sum(input_window_height_per_group_per_prime);
 
       El::BuildStream(os, "  Input residues window (P):\n");
-      El::BuildStream(os, "  Number of windows: ",
+      El::BuildStream(os, "    Number of windows: ",
                       output_window_split_factor == 1 ? 1 : 2, "\n");
       El::BuildStream(
-        os, "    Window size, bytes: ",
-        window_size_bytes(input_window_height, window_width, comb.num_primes),
+        os, "    Window size: ",
+        pretty_print_bytes(window_size_bytes(input_window_height, window_width,
+                                             comb.num_primes),
+                           true),
         "\n");
       El::BuildStream(os, "    Split factor: ", input_window_split_factor,
                       "\n");
       El::BuildStream(os, "    Height (per prime): ", input_window_height,
                       "\n");
       El::BuildStream(os, "    Width: ", window_width, "\n");
-      El::Print(input_window_height_per_group_per_prime,
-                "    Heights for each MPI group:", ", ", os);
-      os << "\n";
-      El::Print(group_comm_sizes, "    MPI group sizes:", ", ", os);
-      os << "\n";
+      os << "    Heights for each MPI group: "
+         << input_window_height_per_group_per_prime << "\n";
+      os << "    MPI group sizes:" << group_comm_sizes << "\n";
 
       El::Output(os.str());
     }

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/Block_Residue_Matrices_Window.hxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/Block_Residue_Matrices_Window.hxx
@@ -29,9 +29,9 @@ public:
   Block_Residue_Matrices_Window(El::mpi::Comm shared_memory_comm,
                                 size_t num_primes, size_t num_blocks,
                                 const std::vector<El::Int> &block_heights,
-                                size_t block_width, bool debug)
+                                size_t block_width)
       : Residue_Matrices_Window<T>(shared_memory_comm, num_primes,
-                                   Sum(block_heights), block_width, debug),
+                                   Sum(block_heights), block_width),
         num_blocks(num_blocks),
         block_residues(num_primes, std::vector<El::Matrix<T>>(num_blocks))
   {

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/Residue_Matrices_Window.hxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/Residue_Matrices_Window.hxx
@@ -24,12 +24,12 @@ private:
 
 public:
   Residue_Matrices_Window(El::mpi::Comm shared_memory_comm, size_t num_primes,
-                          size_t height, size_t width, bool debug)
+                          size_t height, size_t width)
       : num_primes(num_primes),
         height(height),
         width(width),
         prime_stride(height * width),
-        window(shared_memory_comm, num_primes * prime_stride, debug)
+        window(shared_memory_comm, num_primes * prime_stride)
   {
     ASSERT(num_primes > 0);
     ASSERT(height > 0);

--- a/src/sdp_solve/Solver_Parameters/ostream.cxx
+++ b/src/sdp_solve/Solver_Parameters/ostream.cxx
@@ -1,4 +1,5 @@
 #include "../Solver_Parameters.hxx"
+#include "sdpb_util/ostream/pretty_print_bytes.hxx"
 
 std::ostream &operator<<(std::ostream &os, const Solver_Parameters &p)
 {
@@ -6,8 +7,8 @@ std::ostream &operator<<(std::ostream &os, const Solver_Parameters &p)
      << '\n'
      << "maxRuntime                   = " << p.max_runtime << '\n'
      << "checkpointInterval           = " << p.checkpoint_interval << '\n'
-     << "maxSharedMemory              = " << p.max_shared_memory_bytes
-     << '\n'
+     << "maxSharedMemory              = "
+     << pretty_print_bytes(p.max_shared_memory_bytes, true) << '\n'
      << "findPrimalFeasible           = " << p.find_primal_feasible << '\n'
      << "findDualFeasible             = " << p.find_dual_feasible << '\n'
      << "detectPrimalFeasibleJump     = " << p.detect_primal_feasible_jump

--- a/src/sdpb_util/Shared_Window_Array.hxx
+++ b/src/sdpb_util/Shared_Window_Array.hxx
@@ -26,8 +26,7 @@ public:
   //
   // It ensures that all ranks in the communicator are on the same node
   // and can share memory.
-  Shared_Window_Array(El::mpi::Comm shared_memory_comm, size_t size,
-                      bool debug)
+  Shared_Window_Array(El::mpi::Comm shared_memory_comm, size_t size)
       : comm(shared_memory_comm), size(size)
   {
     MPI_Aint local_window_size; // number of bytes allocated by current rank
@@ -35,16 +34,7 @@ public:
 
     // Allocate all memory in rank=0
     if(El::mpi::Rank(shared_memory_comm) == 0)
-      {
-        local_window_size = size * disp_unit;
-        if(debug)
-          {
-            El::Output(
-              El::mpi::Rank(),
-              " Allocate Shared_Window_Array, elements: ", size,
-              ", size, GB: ", (double)local_window_size / 1024 / 1024 / 1024);
-          }
-      }
+      local_window_size = size * disp_unit;
     else
       local_window_size = 0;
 

--- a/src/sdpb_util/copy_matrix.cxx
+++ b/src/sdpb_util/copy_matrix.cxx
@@ -103,8 +103,7 @@ void copy_matrix_from_root_impl_shared_window(
     = El::BigFloat(1).SerializedSize() / sizeof(El::byte);
 
   Shared_Window_Array<El::byte> window(
-    comm, destination.Height() * destination.Width() * bigfloat_size_bytes,
-    false);
+    comm, destination.Height() * destination.Width() * bigfloat_size_bytes);
 
   const int ldim = destination.Height();
   auto get_buffer = [&](int i, int j) -> El::byte * {

--- a/src/sdpb_util/ostream/pretty_print_bytes.hxx
+++ b/src/sdpb_util/ostream/pretty_print_bytes.hxx
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <El.hpp>
+#include <iomanip>
+
+// Pretty pring memory size given in bytes.
+// Examples:
+// also_print_exact=false:
+// - 100 B
+// - 3.1 KB
+// - 1250.0 GB
+// also_print_exact=true:
+// - 100 B
+// - 3.1 KB (3180 bytes)
+inline std::string
+pretty_print_bytes(const size_t bytes, const bool also_print_exact = false)
+{
+  if(bytes < 1024)
+    return El::BuildString(bytes, " B");
+  double value = bytes;
+
+  std::string unit;
+  for(const auto curr_unit : {"KB", "MB", "GB"})
+    {
+      value /= 1024;
+      unit = curr_unit;
+      if(value < 1024)
+        break;
+    }
+
+  std::ostringstream os;
+  El::BuildStream(os, std::fixed, std::setprecision(1), value, " ", unit);
+  if(also_print_exact)
+    El::BuildStream(os, " (", bytes, " bytes)");
+  return os.str();
+}

--- a/test/src/unit_tests/cases/shared_window.test.cxx
+++ b/test/src/unit_tests/cases/shared_window.test.cxx
@@ -18,12 +18,10 @@ TEST_CASE("MPI_Shared_Window")
   MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
                       &comm.comm);
 
-  bool debug = false;
-
   SECTION("Shared_Window_Array")
   {
     size_t size = 10;
-    Shared_Window_Array<double> array(comm, size, debug);
+    Shared_Window_Array<double> array(comm, size);
 
     for(size_t i = 0; i < size; ++i)
       {
@@ -55,8 +53,7 @@ TEST_CASE("MPI_Shared_Window")
       }
 
     // BLAS output will be stored here
-    Residue_Matrices_Window<double> window(comm, num_primes, height, width,
-                                           debug);
+    Residue_Matrices_Window<double> window(comm, num_primes, height, width);
     for(size_t p = 0; p < num_primes; ++p)
       for(size_t i = 0; i < height; ++i)
         for(size_t j = 0; j < width; ++j)
@@ -85,7 +82,7 @@ TEST_CASE("MPI_Shared_Window")
       }
 
     Block_Residue_Matrices_Window<double> window(comm, num_primes, num_blocks,
-                                                 block_heights, width, debug);
+                                                 block_heights, width);
     for(size_t p = 0; p < num_primes; ++p)
       {
         block_residues.at(p).resize(num_blocks);


### PR DESCRIPTION
- Pretty-print bytes, e.g.  `maxSharedMemory = 25.0 GB (26843545600 bytes)`
- Fix RAM estimates printed in `pmp2sdp`
- Fix unnecessary matrix copying in `compute_block_residues()`.
In theory, this should reduce peak RAM usage at this step, but in practice it (almost) doesn't.
- Some code cleanup