### PR TITLE
Minor fixes and improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 # Config for CircleCI
 # See https://circleci.com/docs/configuration-reference
 #
-# This config has a single workflow, 'build-deploy', which goes as follows:
-# 1. 'build-linux-amd64': Builds Docker image from SDPB sources (using ./Dockerfile) for AMD64 platform and run tests
-# 2. 'build-linux-arm64': same for ARM64
+# This config has a single workflow, 'build-test-deploy', which goes as follows:
+# 1. 'build-test-linux-amd64': Builds Docker image from SDPB sources (using ./Dockerfile) for AMD64 platform and run tests
+# 2. 'build-test-linux-arm64': same for ARM64
 # 3. 'deploy-master': On each 'master' branch update, build a multiplatform image (working for both AMD64 and ARM64)
 #     and push it to DockerHub as '${DOCKER_USERNAME}/sdpb:master', e.g. 'davidsd/sdpb:master'.
 # 4. 'deploy-tag': If new tag is pushed to the repo, build and push the multiplatform image
@@ -24,8 +24,8 @@ version: 2.1
 # See https://circleci.com/docs/reusing-config/
 commands:
 
-  docker-build:
-    description: Build Docker image for platform
+  docker-build-test:
+    description: Build and test Docker image for platform
     parameters:
       # linux/amd64, linux/arm64
       # Run 'docker buildx ls' to see all available platforms
@@ -126,21 +126,21 @@ commands:
 # See: https://circleci.com/docs/configuration-reference/#jobs
 jobs:
 
-  build-linux-amd64:
+  build-test-linux-amd64:
     machine:
       image: ubuntu-2004:current
     resource_class: large
     steps:
-      - docker-build:
+      - docker-build-test:
           platform: linux/amd64
           tag: amd64
 
-  build-linux-arm64:
+  build-test-linux-arm64:
     machine:
       image: ubuntu-2004:current
     resource_class: arm.large
     steps:
-      - docker-build:
+      - docker-build-test:
           platform: linux/arm64
           tag: arm64
   
@@ -150,7 +150,7 @@ jobs:
   #      xcode: 15.3.0
   #    resource_class: macos.m1.medium.gen1
   #    steps:
-  #      - docker-build:
+  #      - docker-build-test:
   #          platform: linux/arm64
   #          tag: arm64
 
@@ -187,15 +187,15 @@ jobs:
 # Workflows to be executed
 # See: https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  build-deploy:
+  build-test-deploy:
     jobs:
 
-      - build-linux-amd64:
+      - build-test-linux-amd64:
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/
 
-      - build-linux-arm64:
+      - build-test-linux-arm64:
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/
@@ -205,8 +205,8 @@ workflows:
             branches:
               only: master
           requires:
-            - build-linux-amd64
-            - build-linux-arm64
+            - build-test-linux-amd64
+            - build-test-linux-arm64
 
       - deploy-tag:
           filters:
@@ -218,5 +218,5 @@ workflows:
           # NB: you have to specify tags filter for all dependencies,
           # See https://circleci.com/docs/configuration-reference/#tags
           requires:
-            - build-linux-amd64
-            - build-linux-arm64
+            - build-test-linux-amd64
+            - build-test-linux-arm64

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
 # waf
-.lock-waf*
-.waf*/
-build/
+/.lock-waf*
+/.waf*/
+/build/
 __pycache__/
 /waf-tools/*.pyc
 
 # cmake
-cmake-build*/
+/cmake-build*/
 
 # IDE
 *.code-workspace
@@ -15,8 +15,8 @@ cmake-build*/
 .cache/
 
 # test
-test/out/
-test/.nfs*
+/test/out/
+/test/.nfs*
 
 # TeX
 /docs/**/*.aux
@@ -26,4 +26,4 @@ test/.nfs*
 /docs/**/*.toc
 
 # Misc
-tmp/
+/tmp/

--- a/src/approx_objective/Approx_Parameters/Approx_Parameters.cxx
+++ b/src/approx_objective/Approx_Parameters/Approx_Parameters.cxx
@@ -1,5 +1,6 @@
 #include "../Approx_Parameters.hxx"
 
+#include "sdp_solve/Solver_Parameters/String_To_Bytes_Translator.hxx"
 #include "sdpb_util/assert.hxx"
 
 #include <boost/program_options.hpp>
@@ -41,8 +42,12 @@ Approx_Parameters::Approx_Parameters(int argc, char *argv[])
     "approximate, or a null separated list of files with preprocessed input.");
   basic_options.add_options()(
     "maxSharedMemory",
-    boost::program_options::value<size_t>(&max_shared_memory_bytes)
-      ->default_value(std::numeric_limits<size_t>::max()),
+    boost::program_options::value<std::string>()
+      ->notifier([this](const std::string &s) {
+        this->max_shared_memory_bytes
+          = String_To_Bytes_Translator::from_string(s);
+      })
+      ->default_value("0"),
     "Maximum amount of memory that can be used for MPI shared windows, "
     "in bytes."
     " Optional suffixes: B (bytes), K or KB (kilobytes), M or MB (megabytes), "

--- a/src/approx_objective/setup_solver.cxx
+++ b/src/approx_objective/setup_solver.cxx
@@ -93,6 +93,7 @@ void setup_solver(const Environment &env, const Block_Info &block_info,
 
       Timers timers;
       El::Matrix<int32_t> block_timings_ms(block_info.dimensions.size(), 1);
+      El::Zero(block_timings_ms);
       auto bigint_syrk_context = initialize_bigint_syrk_context(
         env, block_info, sdp, parameters.max_shared_memory_bytes, false);
       initialize_schur_complement_solver(

--- a/src/outer_limits/compute_optimal/compute_optimal.cxx
+++ b/src/outer_limits/compute_optimal/compute_optimal.cxx
@@ -210,6 +210,7 @@ std::vector<El::BigFloat> compute_optimal(
           Timers timers(env, parameters.verbosity >= Verbosity::debug);
           El::Matrix<int32_t> block_timings_ms(block_info.dimensions.size(),
                                                1);
+          El::Zero(block_timings_ms);
           SDP_Solver_Terminate_Reason reason = solver.run(
             env, parameters.solver, parameters.verbosity, parameter_properties,
             block_info, sdp, grid, start_time, timers, block_timings_ms);

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/restore_and_reduce.cxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/restore_and_reduce.cxx
@@ -57,6 +57,7 @@ void BigInt_Shared_Memory_Syrk_Context::restore_and_reduce(
          DEBUG_STRING(output_residues_window->width));
 
   Fmpz_BigInt bigint_value;
+  std::vector<mp_limb_t> residues_buffer_temp(comb.num_primes);
 
   {
     Scoped_Timer local_restore_timer(timers, "local_restore");
@@ -69,7 +70,7 @@ void BigInt_Shared_Memory_Syrk_Context::restore_and_reduce(
             continue;
 
           restore_bigint_from_residues(*output_residues_window, i, j, comb,
-                                       bigint_value);
+                                       residues_buffer_temp, bigint_value);
           const auto iLoc = output.LocalRow(i);
           const auto jLoc = output.LocalCol(j);
           bigint_value.to_BigFloat(output.Matrix()(iLoc, jLoc));
@@ -156,7 +157,8 @@ void BigInt_Shared_Memory_Syrk_Context::restore_and_reduce(
 
                 ASSERT(curr_send - send_buf.data() < send_buf.size());
                 restore_bigint_from_residues(*output_residues_window, i, j,
-                                             comb, bigint_value);
+                                             comb, residues_buffer_temp,
+                                             bigint_value);
                 bigint_value.to_BigFloat(bigfloat_value);
                 bigfloat_value.Serialize(curr_send);
                 curr_send += serialized_size;

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/restore_bigint_from_residues.hxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/restore_bigint_from_residues.hxx
@@ -10,20 +10,22 @@
 inline void
 restore_bigint_from_residues(const Residue_Matrices_Window<double> &window,
                              size_t i, size_t j, Fmpz_Comb &comb,
+                             std::vector<mp_limb_t> &residues_buffer_temp,
                              Fmpz_BigInt &output)
 {
   int sign = 1; // means that negative values are allowed
   size_t num_primes = comb.num_primes;
 
-  std::vector<mp_limb_t> residues(num_primes);
+  residues_buffer_temp.resize(num_primes);
   for(size_t prime_index = 0; prime_index < num_primes; prime_index++)
     {
       double d = window.residues.at(prime_index)(i, j);
       ASSERT(abs(d) <= MAX_BLAS_DP_INT);
       auto &mod = comb.mods.at(prime_index);
-      residues.at(prime_index) = double_to_uint32_t_residue(d, mod);
+      residues_buffer_temp.at(prime_index)
+        = double_to_uint32_t_residue(d, mod);
     }
 
-  fmpz_multi_CRT_ui(output.value, residues.data(), comb.comb, comb.comb_temp,
-                    sign);
+  fmpz_multi_CRT_ui(output.value, residues_buffer_temp.data(), comb.comb,
+                    comb.comb_temp, sign);
 }

--- a/src/sdp_solve/SDP_Solver/run/run.cxx
+++ b/src/sdp_solve/SDP_Solver/run/run.cxx
@@ -155,6 +155,7 @@ SDP_Solver_Terminate_Reason SDP_Solver::run(
       El::mpi::Broadcast(checkpoint_now, 0, El::mpi::COMM_WORLD);
       if(checkpoint_now == true)
         {
+          Scoped_Timer save_timer(timers, "save_checkpoint");
           save_checkpoint(parameters.checkpoint_out, verbosity,
                           parameter_properties);
           last_checkpoint_time = std::chrono::high_resolution_clock::now();

--- a/src/sdp_solve/Solver_Parameters/Solver_Parameters.cxx
+++ b/src/sdp_solve/Solver_Parameters/Solver_Parameters.cxx
@@ -57,7 +57,6 @@ boost::program_options::options_description Solver_Parameters::options()
                        boost::program_options::value<int64_t>(&max_runtime)
                          ->default_value(std::numeric_limits<int64_t>::max()),
                        "Maximum amount of time to run the solver in seconds.");
-  std::string max_shared_memory_string;
   result.add_options()(
     "maxSharedMemory",
     boost::program_options::value<std::string>()
@@ -65,7 +64,7 @@ boost::program_options::options_description Solver_Parameters::options()
         this->max_shared_memory_bytes
           = String_To_Bytes_Translator::from_string(s);
       })
-      ->default_value(std::to_string(std::numeric_limits<size_t>::max())),
+      ->default_value("0"),
     "Maximum amount of memory that can be used for MPI shared windows, "
     "in bytes."
     " Optional suffixes: B (bytes), K or KB (kilobytes), M or MB (megabytes), "

--- a/src/sdp_solve/Solver_Parameters/String_To_Bytes_Translator.hxx
+++ b/src/sdp_solve/Solver_Parameters/String_To_Bytes_Translator.hxx
@@ -24,7 +24,7 @@ struct String_To_Bytes_Translator
   static size_t from_string(const std::string &s)
   {
     std::istringstream iss(s);
-    size_t number;
+    double number;
     std::string suffix;
 
     iss >> number >> suffix;

--- a/src/sdpb/solve.cxx
+++ b/src/sdpb/solve.cxx
@@ -67,16 +67,20 @@ Timers solve(const Block_Info &block_info, const SDPB_Parameters &parameters,
   if(reason == SDP_Solver_Terminate_Reason::SIGTERM_Received
      || !parameters.no_final_checkpoint)
     {
+      Scoped_Timer save_timer(timers, "save_checkpoint");
       solver.save_checkpoint(parameters.solver.checkpoint_out,
                              parameters.verbosity, parameters_tree);
     }
 
-  auto runtime = std::chrono::duration_cast<std::chrono::seconds>(
-                   std::chrono::high_resolution_clock::now() - start_time)
-                   .count();
-  save_solution(solver, reason, runtime, parameters.out_directory,
-                parameters.write_solution, block_info.block_indices,
-                sdp.normalization, parameters.verbosity);
+  {
+    Scoped_Timer save_timer(timers, "save_solution");
+    auto runtime = std::chrono::duration_cast<std::chrono::seconds>(
+                    std::chrono::high_resolution_clock::now() - start_time)
+                    .count();
+    save_solution(solver, reason, runtime, parameters.out_directory,
+                  parameters.write_solution, block_info.block_indices,
+                  sdp.normalization, parameters.verbosity);
+  }
 
   if(reason == SDP_Solver_Terminate_Reason::SIGTERM_Received)
     {

--- a/test/data/outer_limits/out_orig.json
+++ b/test/data/outer_limits/out_orig.json
@@ -9,7 +9,7 @@
 {
     "maxIterations": "1000",
     "maxRuntime": "9223372036854775807",
-    "maxSharedMemory": "18446744073709551615",
+    "maxSharedMemory": "0",
     "checkpointInterval": "3600",
     "findPrimalFeasible": "false",
     "findDualFeasible": "false",

--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -27,9 +27,7 @@ fi
 # For more command-line options, see
 # https://github.com/catchorg/Catch2/blob/devel/docs/command-line.md
 
-# unit_tests: run 4 processes
-# 4 is a minimal number that makes DistMatrix grids two-dimensional (2x2),
-# allowing to catch some bugs e.g. in bigint_syrk/compute_matrix_residues
+# NB: for calculate_matrix_square_test to pass, number of processes must be a multiple of 6
 echo time $MPI_RUN_COMMAND -n 6 ./build/unit_tests --durations yes
 time $MPI_RUN_COMMAND -n 6 ./build/unit_tests --durations yes || { exit $?; }
 

--- a/test/src/integration_tests/cases/end-to-end.test.cxx
+++ b/test/src/integration_tests/cases/end-to-end.test.cxx
@@ -255,7 +255,7 @@ TEST_CASE("end-to-end_tests")
         "--maxComplementarity 1.0e100 --maxIterations 1000 --verbosity 1 "
         "--procGranularity 1 --writeSolution y,z "
         "--detectPrimalFeasibleJump --detectDualFeasibleJump "
-        "--maxSharedMemory=100K"; // forces split_factor=3 for Q window
+        "--maxSharedMemory=100.1K"; // forces split_factor=3 for Q window; also test floating-point --maxSharedMemory value
 
     SECTION("primal_feasible_jump")
     {

--- a/test/src/unit_tests/cases/calculate_matrix_square.test.cxx
+++ b/test/src/unit_tests/cases/calculate_matrix_square.test.cxx
@@ -357,6 +357,7 @@ TEST_CASE("calculate_Block_Matrix_square")
 
                     Timers timers;
                     El::Matrix<int32_t> block_timings_ms(num_blocks, 1);
+                    El::Zero(block_timings_ms);
                     INFO("Calling bigint_syrk_blas()...");
                     context.bigint_syrk_blas(uplo, P_matrix_blocks, Q_result,
                                              timers, block_timings_ms);

--- a/waf-tools/cblas.py
+++ b/waf-tools/cblas.py
@@ -26,7 +26,7 @@ def configure(conf):
         if not conf.options.cblas_incdir:
             conf.options.cblas_incdir = conf.options.cblas_dir + "/include"
         if not conf.options.cblas_libdir:
-            conf.options.cblas_libdir = ' '.join(conf.options.cblas_dir + "/lib", conf.options.cblas_dir + "/lib64")
+            conf.options.cblas_libdir = ' '.join([conf.options.cblas_dir + "/lib", conf.options.cblas_dir + "/lib64"])
 
     if conf.options.cblas_incdir:
         cblas_incdir = conf.options.cblas_incdir.split()

--- a/wscript
+++ b/wscript
@@ -38,7 +38,7 @@ def build(bld):
               cxxflags=default_flags,
               defines=default_defines,
               includes=default_includes,
-              use=['cxx17', 'gmpxx', 'boost', 'elemental'])
+              use=['cxx17', 'gmpxx', 'mpfr', 'boost', 'elemental', 'libxml2', 'rapidjson', 'libarchive', 'cblas'])
 
     sdp_solve_sources = ['src/sdp_solve/Solver_Parameters/Solver_Parameters.cxx',
                          'src/sdp_solve/Solver_Parameters/ostream.cxx',


### PR DESCRIPTION
- Fix #226 
- Reuse residue buffers in `bigint_syrk_blas` to reduce memory traffic.
- Set default `--maxSharedMemory=0` instead of `18446744073709551615` (or `max(size_t)`).
- Allow for floating-point `--maxSharedMemory`, e.g. 1.5GB.
- Add `El::Zero()` in several places.
If `EL_HAVE_VALGRIND=false` and `EL_ZERO_INIT=false`, Elemental does not initialize matrices with zeros by default.
- Add timers for `save_checkpoint` and `save_solution`.