### PR TITLE
Add --verbosity=trace level

### DIFF
--- a/src/approx_objective/main.cxx
+++ b/src/approx_objective/main.cxx
@@ -45,13 +45,26 @@ int main(int argc, char **argv)
         {
           return 0;
         }
+
+      // TODO set verbosity from command line
+      const auto verbosity = Verbosity::regular;
+
+      // Print command line
+      if(verbosity >= Verbosity::debug && El::mpi::Rank() == 0)
+        {
+          std::vector<std::string> arg_list(argv, argv + argc);
+          for(const auto &arg : arg_list)
+            std::cout << arg << " ";
+          std::cout << std::endl;
+        }
+
       Environment::set_precision(parameters.precision);
       Block_Info block_info(env, parameters.sdp_path, parameters.solution_dir,
-                            parameters.proc_granularity, Verbosity::none);
+                            parameters.proc_granularity, verbosity);
 
       El::Grid grid(block_info.mpi_comm.value);
       // TODO use timers also below
-      Timers timers(env, Verbosity::regular);
+      Timers timers(env, verbosity);
       SDP sdp(parameters.sdp_path, block_info, grid, timers);
 
       std::vector<size_t> block_offsets(sdp.free_var_matrix.blocks.size() + 1,

--- a/src/approx_objective/main.cxx
+++ b/src/approx_objective/main.cxx
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
 
       El::Grid grid(block_info.mpi_comm.value);
       // TODO use timers also below
-      Timers timers(env, false);
+      Timers timers(env, Verbosity::regular);
       SDP sdp(parameters.sdp_path, block_info, grid, timers);
 
       std::vector<size_t> block_offsets(sdp.free_var_matrix.blocks.size() + 1,

--- a/src/outer_limits/Outer_Parameters/Outer_Parameters.cxx
+++ b/src/outer_limits/Outer_Parameters/Outer_Parameters.cxx
@@ -39,7 +39,8 @@ Outer_Parameters::Outer_Parameters(int argc, char *argv[])
     "format. Defaults to 'functions' with the ending '_out.json'.");
   basic_options.add_options()("verbosity",
     po::value<Verbosity>(&verbosity)->default_value(Verbosity::regular),
-    "Verbosity.  0 -> no output, 1 -> regular output, 2 -> debug output");
+    "Verbosity.  0 -> no output, 1 -> regular output, 2 -> debug output, 3 -> "
+    "trace output");
 
   cmd_line_options.add(basic_options);
   po::options_description solver_options(solver.options());

--- a/src/outer_limits/compute_optimal/compute_optimal.cxx
+++ b/src/outer_limits/compute_optimal/compute_optimal.cxx
@@ -207,7 +207,7 @@ std::vector<El::BigFloat> compute_optimal(
                         << parameters.solver.duality_gap_threshold << "\n";
             }
 
-          Timers timers(env, parameters.verbosity >= Verbosity::debug);
+          Timers timers(env, parameters.verbosity);
           El::Matrix<int32_t> block_timings_ms(block_info.dimensions.size(),
                                                1);
           El::Zero(block_timings_ms);

--- a/src/pmp2functions/main.cxx
+++ b/src/pmp2functions/main.cxx
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
 
       Environment::set_precision(parameters.precision);
 
-      Timers timers(env, parameters.verbosity >= debug);
+      Timers timers(env, parameters.verbosity);
       const auto pmp
         = read_polynomial_matrix_program(env, parameters.input_file, timers);
       write_functions(parameters.output_path, pmp);

--- a/src/pmp2sdp/Pmp2sdp_Parameters/Pmp2sdp_Parameters.cxx
+++ b/src/pmp2sdp/Pmp2sdp_Parameters/Pmp2sdp_Parameters.cxx
@@ -37,8 +37,8 @@ Pmp2sdp_Parameters::Pmp2sdp_Parameters(int argc, char **argv)
   options.add_options()(
     "verbosity,v",
     po::value<Verbosity>(&verbosity)->default_value(Verbosity::regular),
-    "Verbosity.  0 -> no output, 1 -> regular "
-    "output, 2 -> debug output");
+    "Verbosity.  0 -> no output, 1 -> regular output, 2 -> debug output, 3 -> "
+    "trace output");
 
   // (partial) backward compatibility with pvm2sdp
   po::positional_options_description positional;

--- a/src/pmp2sdp/main.cxx
+++ b/src/pmp2sdp/main.cxx
@@ -33,8 +33,7 @@ int main(int argc, char **argv)
 
       Environment::set_precision(parameters.precision);
 
-      const bool debug = parameters.verbosity >= Verbosity::debug;
-      Timers timers(env, debug);
+      Timers timers(env, parameters.verbosity);
       Scoped_Timer timer(timers, "pmp2sdp");
 
       auto pmp
@@ -42,7 +41,7 @@ int main(int argc, char **argv)
 
       Output_SDP sdp(pmp, parameters.command_arguments, timers);
       write_sdp(parameters.output_path, sdp, parameters.output_format,
-                parameters.zip, timers, debug);
+                parameters.zip, timers, parameters.verbosity);
       if(El::mpi::Rank() == 0)
         {
           El::Output("Processed ", sdp.num_blocks, " SDP blocks in ",
@@ -50,7 +49,7 @@ int main(int argc, char **argv)
                      " seconds, output: ", parameters.output_path.string());
         }
 
-      if(debug)
+      if(parameters.verbosity >= Verbosity::debug)
         {
           timers.write_profile(parameters.output_path.string()
                                + ".profiling/profiling."

--- a/src/pmp2sdp/main.cxx
+++ b/src/pmp2sdp/main.cxx
@@ -30,6 +30,14 @@ int main(int argc, char **argv)
         {
           return 0;
         }
+      // Print command line
+      if(parameters.verbosity >= Verbosity::debug && El::mpi::Rank() == 0)
+        {
+          std::vector<std::string> arg_list(argv, argv + argc);
+          for(const auto &arg : arg_list)
+            std::cout << arg << " ";
+          std::cout << std::endl;
+        }
 
       Environment::set_precision(parameters.precision);
 
@@ -42,7 +50,7 @@ int main(int argc, char **argv)
       Output_SDP sdp(pmp, parameters.command_arguments, timers);
       write_sdp(parameters.output_path, sdp, parameters.output_format,
                 parameters.zip, timers, parameters.verbosity);
-      if(El::mpi::Rank() == 0)
+      if(parameters.verbosity >= Verbosity::regular && El::mpi::Rank() == 0)
         {
           El::Output("Processed ", sdp.num_blocks, " SDP blocks in ",
                      (double)timer.timer().elapsed_milliseconds() / 1000,

--- a/src/pmp2sdp/write_sdp.cxx
+++ b/src/pmp2sdp/write_sdp.cxx
@@ -230,7 +230,7 @@ namespace
 
 void write_sdp(const fs::path &output_path, const Output_SDP &sdp,
                Block_File_Format block_file_format, bool zip, Timers &timers,
-               const bool debug)
+               const Verbosity verbosity)
 {
   Scoped_Timer write_timer(timers, "write_sdp");
 
@@ -328,7 +328,7 @@ void write_sdp(const fs::path &output_path, const Output_SDP &sdp,
           }
       }
   }
-  if(debug)
+  if(verbosity >= Verbosity::debug)
     {
       print_matrix_sizes(rank, sdp.dual_objective_b,
                          sdp.dual_constraint_groups);

--- a/src/pmp2sdp/write_sdp.hxx
+++ b/src/pmp2sdp/write_sdp.hxx
@@ -8,4 +8,4 @@
 
 void write_sdp(const std::filesystem::path &output_path, const Output_SDP &sdp,
                Block_File_Format block_file_format, bool zip, Timers &timers,
-               bool debug);
+               Verbosity verbosity);

--- a/src/pvm2sdp/main.cxx
+++ b/src/pvm2sdp/main.cxx
@@ -26,18 +26,18 @@ int main(int argc, char **argv)
       fs::path output_path;
       std::vector<std::string> command_arguments;
 
-      bool debug = false;
+      Verbosity verbosity = Verbosity::regular;
 
       parse_command_line(argc, argv, output_format, precision, input_files,
                          output_path, command_arguments);
       Environment::set_precision(precision);
 
-      Timers timers(env, debug);
+      Timers timers(env, Verbosity::regular);
 
       auto pmp = read_polynomial_matrix_program(env, input_files, timers);
       Output_SDP sdp(pmp, command_arguments, timers);
       bool zip = false;
-      write_sdp(output_path, sdp, output_format, zip, timers, debug);
+      write_sdp(output_path, sdp, output_format, zip, timers, verbosity);
     }
   catch(std::exception &e)
     {

--- a/src/sdp2input/main.cxx
+++ b/src/sdp2input/main.cxx
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
       int precision;
       fs::path input_file, output_path;
       Block_File_Format output_format;
-      bool debug(false);
+      bool debug;
 
       po::options_description options("Basic options");
       options.add_options()("help,h", "Show this helpful message.");
@@ -76,21 +76,22 @@ int main(int argc, char **argv)
 
       Environment::set_precision(precision);
 
-      Timers timers(env, debug);
+      const auto verbosity = debug ? Verbosity::debug : Verbosity::regular;
+      Timers timers(env, verbosity);
       Scoped_Timer timer(timers, "sdp2input");
 
       auto pmp = read_polynomial_matrix_program(env, input_file, timers);
 
       Output_SDP sdp(pmp, command_arguments, timers);
       bool zip = false;
-      write_sdp(output_path, sdp, output_format, zip, timers, debug);
+      write_sdp(output_path, sdp, output_format, zip, timers, verbosity);
       if(El::mpi::Rank() == 0)
         {
           El::Output("Processed ", sdp.num_blocks, " SDP blocks in ",
                      (double)timer.timer().elapsed_milliseconds() / 1000,
                      " seconds, output: ", output_path.string());
         }
-      if(debug)
+      if(verbosity >= Verbosity::debug)
         {
           timers.write_profile(output_path.string() + ".profiling/profiling."
                                + std::to_string(El::mpi::Rank()));

--- a/src/sdp2input/main.cxx
+++ b/src/sdp2input/main.cxx
@@ -68,6 +68,16 @@ int main(int argc, char **argv)
         }
 
       po::notify(variables_map);
+      const auto verbosity = debug ? Verbosity::debug : Verbosity::regular;
+
+      // Print command line
+      if(verbosity >= Verbosity::debug && El::mpi::Rank() == 0)
+        {
+          std::vector<std::string> arg_list(argv, argv + argc);
+          for(const auto &arg : arg_list)
+            std::cout << arg << " ";
+          std::cout << std::endl;
+        }
 
       ASSERT(fs::exists(input_file),
              "Input file does not exist: ", input_file);
@@ -76,7 +86,6 @@ int main(int argc, char **argv)
 
       Environment::set_precision(precision);
 
-      const auto verbosity = debug ? Verbosity::debug : Verbosity::regular;
       Timers timers(env, verbosity);
       Scoped_Timer timer(timers, "sdp2input");
 

--- a/src/sdp_solve/Block_Info/read_block_costs.cxx
+++ b/src/sdp_solve/Block_Info/read_block_costs.cxx
@@ -62,7 +62,7 @@ Block_Info::read_block_costs(const fs::path &sdp_path,
       El::BigFloat objective_const;
       El::DistMatrix<El::BigFloat> dual_objective_b;
       // TODO pass timers as argument
-      Timers timers(env, false);
+      Timers timers(env, Verbosity::regular);
       // TODO objectives are already read in SDP::SDP(),
       // we should reuse them instead of reading again
       read_objectives(sdp_path, grid, objective_const, dual_objective_b,

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context.hxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context.hxx
@@ -19,10 +19,12 @@ public:
     const std::vector<int> &group_comm_sizes, mp_bitcnt_t precision,
     size_t max_shared_memory_bytes,
     const std::vector<El::Int> &blocks_height_per_group, int block_width,
-    const std::vector<size_t> &block_index_local_to_global, bool debug,
+    const std::vector<size_t> &block_index_local_to_global,
+    Verbosity verbosity,
     const std::function<Blas_Job_Schedule(
-      Blas_Job::Kind kind,El::UpperOrLower uplo, size_t num_ranks, size_t num_primes,
-      int output_height, int output_width, bool debug)> &create_job_schedule
+      Blas_Job::Kind kind, El::UpperOrLower uplo, size_t num_ranks,
+      size_t num_primes, int output_height, int output_width,
+      Verbosity _verbosity)> &create_job_schedule
     = create_blas_job_schedule);
 
   // Calculate Q := P^T P
@@ -59,7 +61,7 @@ private:
   size_t num_groups;
   int total_block_height_per_node;
   Fmpz_Comb comb;
-  const bool debug;
+  const Verbosity verbosity;
   // All blocks from each MPI group are combined
   // into a single block in Block_Residue_Matrices_Window
   std::unique_ptr<Block_Residue_Matrices_Window<double>>
@@ -73,9 +75,10 @@ private:
   size_t output_window_split_factor = 0;
   std::unique_ptr<Residue_Matrices_Window<double>> output_residues_window;
   const std::vector<size_t> block_index_local_to_global;
-  std::function<Blas_Job_Schedule(
-    Blas_Job::Kind kind, El::UpperOrLower uplo, size_t num_ranks,
-    size_t num_primes, int output_height, int output_width, bool debug)>
+  std::function<Blas_Job_Schedule(Blas_Job::Kind kind, El::UpperOrLower uplo,
+                                  size_t num_ranks, size_t num_primes,
+                                  int output_height, int output_width,
+                                  Verbosity verbosity)>
     create_blas_job_schedule_func;
   std::map<std::tuple<Blas_Job::Kind, El::UpperOrLower, El::Int, El::Int>,
            std::shared_ptr<Blas_Job_Schedule>>
@@ -98,10 +101,9 @@ private:
     const El::Range<El::Int> &output_I, const El::Range<El::Int> &output_J,
     Timers &timers, El::Matrix<int32_t> &block_timings_ms);
 
-  void restore_and_reduce(
-    std::optional<El::UpperOrLower> uplo,
-    El::DistMatrix<El::BigFloat> &output,
-    Timers &timers);
+  void
+  restore_and_reduce(std::optional<El::UpperOrLower> uplo,
+                     El::DistMatrix<El::BigFloat> &output, Timers &timers);
 
   [[nodiscard]] El::Int input_group_height_per_prime() const;
 };

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/BigInt_Shared_Memory_Syrk_Context.cxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/BigInt_Shared_Memory_Syrk_Context.cxx
@@ -115,18 +115,19 @@ BigInt_Shared_Memory_Syrk_Context::BigInt_Shared_Memory_Syrk_Context(
   const std::vector<int> &group_comm_sizes, const mp_bitcnt_t precision,
   size_t max_shared_memory_bytes,
   const std::vector<El::Int> &blocks_height_per_group, const int block_width,
-  const std::vector<size_t> &block_index_local_to_global, const bool debug,
+  const std::vector<size_t> &block_index_local_to_global,
+  const Verbosity verbosity,
   const std::function<Blas_Job_Schedule(
     Blas_Job::Kind kind, El::UpperOrLower uplo, size_t num_ranks,
-    size_t num_primes, int output_height, int output_width, bool Debug)>
-    &create_job_schedule)
+    size_t num_primes, int output_height, int output_width,
+    Verbosity _verbosity)> &create_job_schedule)
     : shared_memory_comm(shared_memory_comm),
       group_index(group_index),
       group_comm_sizes(group_comm_sizes),
       num_groups(group_comm_sizes.size()),
       total_block_height_per_node(sum(blocks_height_per_group)),
       comb(precision, precision, 1, total_block_height_per_node),
-      debug(debug),
+      verbosity(verbosity),
       block_index_local_to_global(block_index_local_to_global),
       create_blas_job_schedule_func(create_job_schedule)
 {
@@ -260,7 +261,7 @@ BigInt_Shared_Memory_Syrk_Context::BigInt_Shared_Memory_Syrk_Context(
     }
 
   // Print sizes
-  if(debug && shared_memory_comm.Rank() == 0)
+  if(verbosity >= Verbosity::debug && shared_memory_comm.Rank() == 0)
     {
       std::ostringstream os;
       El::BuildStream(os, "create BigInt_Shared_Memory_Syrk_Context, rank=",

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/get_blas_job_schedule.cxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/get_blas_job_schedule.cxx
@@ -13,7 +13,7 @@ BigInt_Shared_Memory_Syrk_Context::get_blas_job_schedule(Blas_Job::Kind kind,
   auto [it, res] = blas_job_schedule_cache.emplace(
     key, std::make_shared<Blas_Job_Schedule>(create_blas_job_schedule_func(
            kind, uplo, shared_memory_comm.Size(), comb.num_primes,
-           output_height, output_width, debug)));
+           output_height, output_width, verbosity)));
   ASSERT(res);
   return it->second;
 }

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/blas_jobs/create_blas_job_schedule.cxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/blas_jobs/create_blas_job_schedule.cxx
@@ -1,6 +1,7 @@
 #include "create_blas_jobs_schedule.hxx"
 
 #include "Blas_Job_Schedule.hxx"
+#include "sdpb_util/Verbosity.hxx"
 #include "sdpb_util/assert.hxx"
 #include "sdpb_util/split_range.hxx"
 
@@ -150,7 +151,8 @@ create_blas_job_schedule(const Blas_Job::Kind kind,
                          const El::UpperOrLowerNS::UpperOrLower uplo,
                          const size_t num_ranks, const size_t num_primes,
                          const El::Int output_matrix_height,
-                         const El::Int output_matrix_width, const bool debug)
+                         const El::Int output_matrix_width,
+                         const Verbosity verbosity)
 {
   const auto all_ranks_cost
     = kind == Blas_Job::syrk
@@ -161,7 +163,7 @@ create_blas_job_schedule(const Blas_Job::Kind kind,
     = minimal_split_factor(kind, num_ranks, num_primes % num_ranks,
                            output_matrix_height, output_matrix_width);
 
-  if(debug && El::mpi::Rank() == 0)
+  if(verbosity >= Verbosity::debug && El::mpi::Rank() == 0)
     {
       El::Output("-----------------------------");
       El::Output("Creating BLAS job schedule...");
@@ -198,7 +200,7 @@ create_blas_job_schedule(const Blas_Job::Kind kind,
           best_split_factor = split_factor;
         }
 
-      if(debug && El::mpi::Rank() == 0)
+      if(verbosity >= Verbosity::debug && El::mpi::Rank() == 0)
         {
           auto [max_rank_cost, num_jobs] = cost;
           El::Output("Checking split_factor=", split_factor,
@@ -208,7 +210,7 @@ create_blas_job_schedule(const Blas_Job::Kind kind,
         }
     }
 
-  if(debug && El::mpi::Rank() == 0)
+  if(verbosity >= Verbosity::debug && El::mpi::Rank() == 0)
     {
       El::Output("Choosing the optimal split_factor=", best_split_factor);
       El::Output("For the first ", num_primes - num_primes % num_ranks,

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/blas_jobs/create_blas_jobs_schedule.hxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/blas_jobs/create_blas_jobs_schedule.hxx
@@ -2,6 +2,7 @@
 
 #include "Blas_Job.hxx"
 #include "Blas_Job_Schedule.hxx"
+#include "sdpb_util/Verbosity.hxx"
 
 // Create BLAS jobs for matrix multiplication C = A^T B.
 // Each job calculates a submatrix C_IJ = A_I^T B_J modulo some prime
@@ -15,4 +16,4 @@ create_blas_job_schedule(Blas_Job::Kind kind,
                          El::UpperOrLowerNS::UpperOrLower uplo,
                          size_t num_ranks, size_t num_primes,
                          El::Int output_matrix_height,
-                         El::Int output_matrix_width, bool debug);
+                         El::Int output_matrix_width, Verbosity verbosity);

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/initialize_bigint_syrk_context.hxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/initialize_bigint_syrk_context.hxx
@@ -103,7 +103,7 @@ inline BigInt_Shared_Memory_Syrk_Context
 initialize_bigint_syrk_context(const Environment &env,
                                const Block_Info &block_info, const SDP &sdp,
                                const size_t max_shared_memory_bytes,
-                               const bool debug)
+                               const Verbosity verbosity)
 {
   const Grouped_Block_Size_Info info(env, block_info, sdp);
 
@@ -111,5 +111,5 @@ initialize_bigint_syrk_context(const Environment &env,
     env.comm_shared_mem, info.group_index, info.group_comm_sizes,
     El::gmp::Precision(), max_shared_memory_bytes,
     info.blocks_height_per_group, info.block_width, block_info.block_indices,
-    debug);
+    verbosity);
 }

--- a/src/sdp_solve/SDP_Solver/run/print_iteration.cxx
+++ b/src/sdp_solve/SDP_Solver/run/print_iteration.cxx
@@ -99,7 +99,7 @@ void print_iteration(
       ASSERT(max_block_cond_number >= 1, DEBUG_STRING(max_block_cond_number));
       ASSERT(!max_block_cond_number_name.empty());
     }
-  if(verbosity >= Verbosity::debug)
+  if(verbosity >= Verbosity::trace)
     {
       El::Output("Cholesky condition number of Q: ", Q_cond_number);
       El::Output("Max Cholesky condition number among blocks: ",

--- a/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/initialize_schur_complement_solver.cxx
+++ b/src/sdp_solve/SDP_Solver/run/step/initialize_schur_complement_solver/initialize_schur_complement_solver.cxx
@@ -57,7 +57,7 @@ void compute_Q(const Environment &env, const SDP &sdp,
                Block_Diagonal_Matrix &schur_complement_cholesky,
                BigInt_Shared_Memory_Syrk_Context &bigint_syrk_context,
                El::DistMatrix<El::BigFloat> &Q, Timers &timers,
-               El::Matrix<int32_t> &block_timings_ms, bool debug);
+               El::Matrix<int32_t> &block_timings_ms, Verbosity verbosity);
 
 void initialize_schur_complement_solver(
   const Environment &env, const Block_Info &block_info, const SDP &sdp,
@@ -71,7 +71,7 @@ void initialize_schur_complement_solver(
   Block_Matrix &schur_off_diagonal,
   BigInt_Shared_Memory_Syrk_Context &bigint_syrk_context,
   El::DistMatrix<El::BigFloat> &Q, Timers &timers,
-  El::Matrix<int32_t> &block_timings_ms, const bool debug)
+  El::Matrix<int32_t> &block_timings_ms, const Verbosity verbosity)
 {
   Scoped_Timer initialize_timer(timers, "initializeSchurComplementSolver");
   // The Schur complement matrix S: a Block_Diagonal_Matrix with one
@@ -81,17 +81,16 @@ void initialize_schur_complement_solver(
   Block_Diagonal_Matrix schur_complement(
     block_info.schur_block_sizes(), block_info.block_indices,
     block_info.num_points.size(), group_grid);
-  if(debug)
+  if(verbosity >= Verbosity::trace)
     {
-      print_allocation_message_per_node(
-        env, "schur_complement",
-        get_allocated_bytes(schur_complement));
+      print_allocation_message_per_node(env, "schur_complement",
+                                        get_allocated_bytes(schur_complement));
     }
   compute_schur_complement(block_info, A_X_inv, A_Y, schur_complement, timers);
 
   compute_Q(env, sdp, block_info, schur_complement, schur_off_diagonal,
             schur_complement_cholesky, bigint_syrk_context, Q, timers,
-            block_timings_ms, debug);
+            block_timings_ms, verbosity);
 
   Scoped_Timer Cholesky_timer(timers, "Cholesky_Q");
   try

--- a/src/sdpb/SDPB_Parameters/SDPB_Parameters.cxx
+++ b/src/sdpb/SDPB_Parameters/SDPB_Parameters.cxx
@@ -53,7 +53,8 @@ SDPB_Parameters::SDPB_Parameters(int argc, char *argv[])
   basic_options.add_options()(
     "verbosity",
     po::value<Verbosity>(&verbosity)->default_value(Verbosity::regular),
-    "Verbosity.  0 -> no output, 1 -> regular output, 2 -> debug output");
+    "Verbosity.  0 -> no output, 1 -> regular output, 2 -> debug output, 3 -> "
+    "trace output");
 
   po::options_description obsolete_options("Obsolete options");
   obsolete_options.add_options()(

--- a/src/sdpb/main.cxx
+++ b/src/sdpb/main.cxx
@@ -44,6 +44,14 @@ int main(int argc, char **argv)
       auto start_time = std::chrono::high_resolution_clock::now();
       if(parameters.verbosity >= Verbosity::regular && El::mpi::Rank() == 0)
         {
+          // Print command line
+          if(parameters.verbosity >= Verbosity::debug)
+            {
+              std::vector<std::string> arg_list(argv, argv + argc);
+              for(const auto &arg : arg_list)
+                std::cout << arg << " ";
+              std::cout << std::endl;
+            }
           std::cout << boost::posix_time::second_clock::local_time()
                     << " Start SDPB" << '\n'
                     << "SDPB version: " << SDPB_VERSION_STRING << '\n'

--- a/src/sdpb/main.cxx
+++ b/src/sdpb/main.cxx
@@ -24,7 +24,7 @@ Timers solve(const Block_Info &block_info, const SDPB_Parameters &parameters,
 void write_block_timings(const fs::path &checkpoint_out,
                          const Block_Info &block_info,
                          const El::Matrix<int32_t> &block_timings_ms,
-                         const bool &debug);
+                         Verbosity verbosity);
 
 void write_profiling(const fs::path &checkpoint_out, const Timers &timers);
 
@@ -52,7 +52,7 @@ int main(int argc, char **argv)
                     << parameters << std::endl;
         }
 
-      if(parameters.verbosity >= debug)
+      if(parameters.verbosity >= Verbosity::debug)
         {
           if(env.comm_shared_mem.Rank() == 0)
             {
@@ -60,8 +60,7 @@ int main(int argc, char **argv)
               auto meminfo = Proc_Meminfo::try_read(res, true);
               if(res)
                 {
-                  El::Output("node=", env.node_index(),
-                             ": MemUsed: ",
+                  El::Output("node=", env.node_index(), ": MemUsed: ",
                              pretty_print_bytes(meminfo.mem_used()));
                 }
             }
@@ -98,7 +97,7 @@ int main(int argc, char **argv)
           timing_parameters.solver.dual_error_threshold = 0;
           timing_parameters.solver.min_primal_step = 0;
           timing_parameters.solver.min_dual_step = 0;
-          if(timing_parameters.verbosity != Verbosity::debug)
+          if(timing_parameters.verbosity < Verbosity::debug)
             {
               timing_parameters.verbosity = Verbosity::none;
             }
@@ -115,7 +114,7 @@ int main(int argc, char **argv)
 
           write_block_timings(timing_parameters.solver.checkpoint_out,
                               block_info, block_timings_ms,
-                              timing_parameters.verbosity >= Verbosity::debug);
+                              timing_parameters.verbosity);
           if(timing_parameters.verbosity >= Verbosity::debug)
             {
               try

--- a/src/sdpb/solve.cxx
+++ b/src/sdpb/solve.cxx
@@ -26,14 +26,14 @@ Timers solve(const Block_Info &block_info, const SDPB_Parameters &parameters,
                &start_time,
              El::Matrix<int32_t> &block_timings_ms)
 {
-  Timers timers(env, parameters.verbosity >= Verbosity::debug);
+  Timers timers(env, parameters.verbosity);
   Scoped_Timer solve_timer(timers, "sdpb.solve");
 
   El::Grid grid(block_info.mpi_comm.value);
 
   Scoped_Timer read_sdp_timer(timers, "read_sdp");
   SDP sdp(parameters.sdp_path, block_info, grid, timers);
-  if(parameters.verbosity >= debug)
+  if(parameters.verbosity >= Verbosity::debug)
     {
       print_allocation_message_per_node(env, "SDP", get_allocated_bytes(sdp));
     }
@@ -49,7 +49,7 @@ Timers solve(const Block_Info &block_info, const SDPB_Parameters &parameters,
   SDP_Solver solver(parameters.solver, parameters.verbosity,
                     parameters.require_initial_checkpoint, block_info, grid,
                     sdp.dual_objective_b.Height());
-  if(parameters.verbosity >= debug)
+  if(parameters.verbosity >= Verbosity::debug)
     {
       print_allocation_message_per_node(env, "SDP_Solver",
                                         get_allocated_bytes(solver));

--- a/src/sdpb/write_timing.cxx
+++ b/src/sdpb/write_timing.cxx
@@ -34,12 +34,12 @@ void write_profiling(const fs::path &checkpoint_out, const Timers &timers)
 void write_block_timings(const fs::path &checkpoint_out,
                          const Block_Info &block_info,
                          const El::Matrix<int32_t> &block_timings_ms,
-                         const bool &debug)
+                         const Verbosity verbosity)
 {
   if(El::mpi::Rank() != 0)
     return;
 
-  if(debug)
+  if(verbosity >= Verbosity::debug)
     {
       El::Print(block_timings_ms, "block_timings, ms:", ", ");
       El::Output();

--- a/src/sdpb_util/Timers/Timers.hxx
+++ b/src/sdpb_util/Timers/Timers.hxx
@@ -9,6 +9,7 @@
 
 #include "Timer.hxx"
 #include "sdpb_util/Environment.hxx"
+#include "sdpb_util/Verbosity.hxx"
 
 #include <El.hpp>
 
@@ -29,7 +30,7 @@ private:
   std::list<std::pair<std::string, Timer>> named_timers;
   std::string prefix;
 
-  bool print_debug_info = false;
+  Verbosity verbosity = Verbosity::regular;
   std::string node_debug_prefix;
 
   bool can_read_meminfo = true;
@@ -40,7 +41,7 @@ private:
 
 public:
   Timers();
-  Timers(const Environment &env, bool debug);
+  Timers(const Environment &env, const Verbosity &verbosity);
   ~Timers() noexcept;
 
 private:
@@ -49,7 +50,7 @@ private:
 public:
   void write_profile(const std::filesystem::path &path) const;
 
-  int64_t elapsed_milliseconds(const std::string &s) const;
+  [[nodiscard]] int64_t elapsed_milliseconds(const std::string &s) const;
 
 private:
   void print_max_mem_used() const;

--- a/src/sdpb_util/Verbosity.hxx
+++ b/src/sdpb_util/Verbosity.hxx
@@ -3,6 +3,8 @@
 #include <istream>
 #include <string>
 
+#include <boost/algorithm/string.hpp>
+
 enum Verbosity
 {
   none = 0,
@@ -15,6 +17,7 @@ inline std::istream &operator>>(std::istream &in, Verbosity &value)
 {
   std::string token;
   in >> token;
+  boost::algorithm::to_lower(token);
 
   if(token == "0" || token == "none")
     value = none;

--- a/src/sdpb_util/Verbosity.hxx
+++ b/src/sdpb_util/Verbosity.hxx
@@ -7,7 +7,8 @@ enum Verbosity
 {
   none = 0,
   regular = 1,
-  debug = 2
+  debug = 2,
+  trace = 3,
 };
 
 inline std::istream &operator>>(std::istream &in, Verbosity &value)
@@ -21,6 +22,8 @@ inline std::istream &operator>>(std::istream &in, Verbosity &value)
     value = regular;
   else if(token == "2" || token == "debug")
     value = debug;
+  else if(token == "3" || token == "trace")
+    value = trace;
   else
     in.setstate(std::ios_base::failbit);
 

--- a/src/sdpb_util/memory_estimates.cxx
+++ b/src/sdpb_util/memory_estimates.cxx
@@ -13,7 +13,7 @@ size_t bigfloat_bytes()
 
 size_t get_max_shared_memory_bytes(
   const size_t nonshared_memory_required_per_node_bytes,
-  const Environment &env, const bool debug)
+  const Environment &env, const Verbosity verbosity)
 {
   El::byte can_update = false;
   // will be set only on rank=0
@@ -21,7 +21,8 @@ size_t get_max_shared_memory_bytes(
   if(env.comm_shared_mem.Rank() == 0)
     {
       bool res;
-      const auto meminfo = Proc_Meminfo::try_read(res, debug);
+      const auto meminfo
+        = Proc_Meminfo::try_read(res, verbosity >= Verbosity::debug);
       mem_total_bytes = meminfo.mem_total;
       can_update = res;
     }

--- a/src/sdpb_util/memory_estimates.hxx
+++ b/src/sdpb_util/memory_estimates.hxx
@@ -8,7 +8,7 @@
 
 size_t
 get_max_shared_memory_bytes(size_t nonshared_memory_required_per_node_bytes,
-                            const Environment &env, bool debug);
+                            const Environment &env, Verbosity verbosity);
 
 size_t get_matrix_size_local(const Block_Diagonal_Matrix &X);
 size_t get_A_X_size_local(const Block_Info &block_info, const SDP &sdp);

--- a/src/spectrum/handle_arguments.cxx
+++ b/src/spectrum/handle_arguments.cxx
@@ -1,5 +1,6 @@
 #include "sdpb_util/Boost_Float.hxx"
 #include "sdpb_util/Environment.hxx"
+#include "sdpb_util/Verbosity.hxx"
 #include "sdpb_util/assert.hxx"
 
 #include <El.hpp>
@@ -12,7 +13,7 @@ namespace fs = std::filesystem;
 void handle_arguments(const int &argc, char **argv, El::BigFloat &threshold,
                       El::BigFloat &mesh_threshold, fs::path &input_path,
                       fs::path &solution_dir, fs::path &output_path,
-                      bool &need_lambda)
+                      bool &need_lambda, Verbosity &verbosity)
 {
   int precision;
   std::string threshold_string, mesh_threshold_string, format_string;
@@ -45,6 +46,11 @@ void handle_arguments(const int &argc, char **argv, El::BigFloat &threshold,
   options.add_options()("lambda",
                         po::value<bool>(&need_lambda)->default_value(true),
                         "If true, compute Λ and its associated error.");
+  options.add_options()(
+    "verbosity",
+    po::value<Verbosity>(&verbosity)->default_value(Verbosity::regular),
+    "Verbosity.  0 -> no output, 1 -> regular output, 2 -> debug output, 3 -> "
+    "trace output");
 
   options.add_options()(
     "format", po::value<std::string>(&format_string),

--- a/src/spectrum/main.cxx
+++ b/src/spectrum/main.cxx
@@ -10,7 +10,7 @@ namespace fs = std::filesystem;
 void handle_arguments(const int &argc, char **argv, El::BigFloat &threshold,
                       El::BigFloat &mesh_threshold, fs::path &input_path,
                       fs::path &solution_path, fs::path &output_path,
-                      bool &need_lambda);
+                      bool &need_lambda, Verbosity& verbosity);
 
 std::vector<El::Matrix<El::BigFloat>>
 read_x(const fs::path &solution_path,
@@ -40,11 +40,10 @@ int main(int argc, char **argv)
       El::BigFloat threshold, mesh_threshold;
       fs::path input_path, solution_dir, output_path;
       bool need_lambda;
+      Verbosity verbosity;
       handle_arguments(argc, argv, threshold, mesh_threshold, input_path,
-                       solution_dir, output_path, need_lambda);
+                       solution_dir, output_path, need_lambda, verbosity);
 
-      // TODO set verbosity from command line
-      const auto verbosity = Verbosity::regular;
       // Print command line
       if(verbosity >= Verbosity::debug && El::mpi::Rank() == 0)
         {

--- a/src/spectrum/main.cxx
+++ b/src/spectrum/main.cxx
@@ -45,6 +45,15 @@ int main(int argc, char **argv)
 
       // TODO set verbosity from command line
       const auto verbosity = Verbosity::regular;
+      // Print command line
+      if(verbosity >= Verbosity::debug && El::mpi::Rank() == 0)
+        {
+          std::vector<std::string> arg_list(argv, argv + argc);
+          for(const auto &arg : arg_list)
+            std::cout << arg << " ";
+          std::cout << std::endl;
+        }
+
       Timers timers(env, verbosity);
       const auto pmp = read_polynomial_matrix_program(env, input_path, timers);
       const size_t num_blocks = pmp.num_matrices;

--- a/src/spectrum/main.cxx
+++ b/src/spectrum/main.cxx
@@ -43,8 +43,9 @@ int main(int argc, char **argv)
       handle_arguments(argc, argv, threshold, mesh_threshold, input_path,
                        solution_dir, output_path, need_lambda);
 
-      bool debug = false; // TODO set verbosity from command line
-      Timers timers(env, debug);
+      // TODO set verbosity from command line
+      const auto verbosity = Verbosity::regular;
+      Timers timers(env, verbosity);
       const auto pmp = read_polynomial_matrix_program(env, input_path, timers);
       const size_t num_blocks = pmp.num_matrices;
       const auto &block_indices = pmp.matrix_index_local_to_global;

--- a/test/src/integration_tests/cases/end-to-end.test.cxx
+++ b/test/src/integration_tests/cases/end-to-end.test.cxx
@@ -230,7 +230,7 @@ TEST_CASE("end-to-end_tests")
         "--dualErrorThreshold 1.0e-30 --initialMatrixScalePrimal 1.0e20 "
         "--initialMatrixScaleDual 1.0e20 --feasibleCenteringParameter 0.1 "
         "--infeasibleCenteringParameter 0.3 --stepLengthReduction 0.7 "
-        "--maxComplementarity 1.0e100 --maxIterations 1000 --verbosity 1 "
+        "--maxComplementarity 1.0e100 --maxIterations 1000 --verbosity 2 "
         "--procGranularity 1 --writeSolution x,y,z";
     // This test is slow, we don't want to run it for both json and binary SDP.
     // json/bin correctness is checked by other tests,
@@ -256,7 +256,7 @@ TEST_CASE("end-to-end_tests")
         "--dualErrorThreshold 1.0e-200 --initialMatrixScalePrimal 1.0e20 "
         "--initialMatrixScaleDual 1.0e20 --feasibleCenteringParameter 0.1 "
         "--infeasibleCenteringParameter 0.3 --stepLengthReduction 0.7 "
-        "--maxComplementarity 1.0e100 --maxIterations 1000 --verbosity 1 "
+        "--maxComplementarity 1.0e100 --maxIterations 1000 --verbosity 2 "
         "--procGranularity 1 --writeSolution y,z "
         "--detectPrimalFeasibleJump --detectDualFeasibleJump "
         "--maxSharedMemory=100.1K"; // forces split_factor=3 for Q window; also test floating-point --maxSharedMemory value

--- a/test/src/unit_tests/cases/calculate_matrix_square.test.cxx
+++ b/test/src/unit_tests/cases/calculate_matrix_square.test.cxx
@@ -326,7 +326,7 @@ TEST_CASE("calculate_Block_Matrix_square")
                     = [&blas_schedule_split_factor](
                         Blas_Job::Kind kind, El::UpperOrLower uplo,
                         size_t num_ranks, size_t num_primes, int output_height,
-                        int output_width, bool debug) {
+                        int output_width, Verbosity verbosity) {
                         return create_blas_job_schedule_split_remaining_primes(
                           kind, uplo, num_ranks, num_primes, output_height,
                           output_width, blas_schedule_split_factor);
@@ -348,12 +348,12 @@ TEST_CASE("calculate_Block_Matrix_square")
                                      num_groups_per_node, node_comm);
 
                   {
-                    const bool debug = false;
+                    const Verbosity verbosity = Verbosity::regular;
                     BigInt_Shared_Memory_Syrk_Context context(
                       node_comm, group_index_in_node,
                       group_comm_sizes_per_node, bits, max_shared_memory_bytes,
                       blocks_height_per_group, block_width, block_indices,
-                      debug, create_job_schedule);
+                      verbosity, create_job_schedule);
 
                     Timers timers;
                     El::Matrix<int32_t> block_timings_ms(num_blocks, 1);

--- a/test/src/unit_tests/cases/create_blas_job_schedule.test.cxx
+++ b/test/src/unit_tests/cases/create_blas_job_schedule.test.cxx
@@ -23,8 +23,9 @@ TEST_CASE("create_blas_jobs_schedule")
     const auto Q_width = Q_height;
     // TODO test also gemm
     constexpr auto uplo = El::UPPER;
-    auto schedule = create_blas_job_schedule(
-      Blas_Job::syrk, uplo, num_ranks, num_primes, Q_height, Q_width, false);
+    auto schedule
+      = create_blas_job_schedule(Blas_Job::syrk, uplo, num_ranks, num_primes,
+                                 Q_height, Q_width, Verbosity::regular);
     {
       INFO("Check that schedule has correct number of ranks:");
       DIFF(schedule.jobs_by_rank.size(), num_ranks);


### PR DESCRIPTION
Added extra verbosity level `--verbosity=trace` (or 3) to SDPB and other executables.
For `--verbosity=debug`, we print all extra info that does not mess up with iterations table - e.g. block mapping, memory estimates etc.
For `--verbosity=trace`, we print everything (e.g. start of each timer).