### PR TITLE
Minor fixes: UB in compute_block_grid_mapping(), tests for iterations.json, compilation

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -267,6 +267,15 @@ sdpb -s path/to/sdp_dir <...>
 Elemental throws this error if you are trying to compute Cholesky decomposition of a matrix that is not Hermitian positive definite (HPD).
 Try increasing SDPB `--precision` and/or precision of your PMP input files.
 
+### 'Illegal instruction' crash
+
+This crash has been observed when FLINT binaries compiled on one CPU are used on another CPU which does not support some extensions (e.g. AVX).
+For example, this may happen in HPC environment when the code is compiled on a login node and used on a compute node.
+
+Workaround: rebuild FLINT, prodiving `--host` option for `configure` script, e.g. `./configure --host=amd64 <...>`.
+
+See more details in https://github.com/davidsd/sdpb/issues/235.
+
 ### 'Running out of inodes' error
 
 This may happen on some filesystems if SDP contains too many block files. Run `pmp2sdp` with `--zip` flag to put

--- a/docs/site_installs/Apple_MacBook.md
+++ b/docs/site_installs/Apple_MacBook.md
@@ -1,6 +1,6 @@
 # Apple MacBook
 
-These instructions have been tested for MacBook Air M2 and for MacBook Air 2017 (Intel i5).
+These instructions have been tested for MacBook Air M1, MacBook Air M2 and MacBook Air 2017 (Intel i5).
 
 The only difference is that for ARM processors you have to set `-arch arm64` compiler flag for sdpb (see below).
 
@@ -18,12 +18,14 @@ Then you can install packages required for SDPB:
 You can see installation directory and another information for a package (e.g. `boost`)
 by calling `brew info <package>` (e.g. `brew info boost`).
 
-## Python 2
+## Python
 
-If Python 2 is missing, install it using macOS installer from https://www.python.org/downloads/release/python-2718/
+On some laptops, waf fails with `bunzip2: Data integrity error when decompressing` when
+using default Python 3.
 
-You may try to skip this step, but note that waf fails with `bunzip2: Data integrity error when decompressing` when
-using default Python 3, at least on some laptops.
+In that case, you should install Python 2 using macOS installer from https://www.python.org/downloads/release/python-2718/
+
+On other laptops, Python 2 fails instead, so that one has to call `python3 ./waf` instead of `./waf` for all waf commands (`waf configure`, `waf`, `waf install`).
 
 ## Elemental
 
@@ -43,7 +45,7 @@ using default Python 3, at least on some laptops.
 
 ### Configure
 
-    ./waf configure --elemental-dir=$HOME/install --boost-dir=/opt/homebrew/opt/boost/ --gmpxx-dir=/opt/homebrew/Cellar/gmp/6.3.0/ --mpfr-dir=/opt/homebrew/Cellar/mpfr/4.2.1/ --rapidjson-dir=/opt/homebrew/Cellar/rapidjson/1.1.0 --libarchive-dir=/opt/homebrew/Cellar/libarchive/3.7.2/ --flint-dir=/opt/homebrew/Cellar/flint/3.1.0 --cblas-dir=/opt/homebrew/Cellar/openblas/0.3.26 --prefix=$HOME/install/sdpb-master
+    CXXFLAGS="${CXXFLAGS} -D_GNU_SOURCE=1" ./waf configure --elemental-dir=$HOME/install --boost-dir=/opt/homebrew/Cellar/boost/1.84.0_1 --gmpxx-dir=/opt/homebrew/Cellar/gmp/6.3.0 --mpfr-dir=/opt/homebrew/Cellar/mpfr/4.2.1 --rapidjson-dir=/opt/homebrew/Cellar/rapidjson/1.1.0 --libarchive-dir=/opt/homebrew/Cellar/libarchive/3.7.3 --flint-dir=/opt/homebrew/Cellar/flint/3.1.0 --cblas-dir=/opt/homebrew/Cellar/openblas/0.3.27 --prefix=$HOME/install/sdpb-master
 
 If waf fails to find some package, e.g. `boost`, check the installation directory by calling, e.g. `brew info boost` and
 update `--boost-dir` argument above.
@@ -52,7 +54,7 @@ The above `./waf configure` command works or x86 processors (e.g. Intel i5), but
 M2) with linker warnings `found architecture 'arm64', required architecture 'x86_64` in `build/config.log`.
 In that case, you should set `-arch arm64` flag explicitly:
 
-    CXXFLAGS="${CXXFLAGS} -arch arm64" LDFLAGS="${LDFLAGS} -arch arm64" ./waf configure --elemental-dir=$HOME/install --boost-dir=/opt/homebrew/opt/boost/ --gmpxx-dir=/opt/homebrew/Cellar/gmp/6.3.0/ --mpfr-dir=/opt/homebrew/Cellar/mpfr/4.2.1/ --rapidjson-dir=/opt/homebrew/Cellar/rapidjson/1.1.0 --libarchive-dir=/opt/homebrew/Cellar/libarchive/3.7.2/ --flint-dir=/opt/homebrew/Cellar/flint/3.1.0 --cblas-dir=/opt/homebrew/Cellar/openblas/0.3.26 --prefix=$HOME/install/sdpb-master
+    CXXFLAGS="${CXXFLAGS} -D_GNU_SOURCE=1 -arch arm64" LDFLAGS="${LDFLAGS} -arch arm64" ./waf configure --elemental-dir=$HOME/install --boost-dir=/opt/homebrew/Cellar/boost/1.84.0_1 --gmpxx-dir=/opt/homebrew/Cellar/gmp/6.3.0 --mpfr-dir=/opt/homebrew/Cellar/mpfr/4.2.1 --rapidjson-dir=/opt/homebrew/Cellar/rapidjson/1.1.0 --libarchive-dir=/opt/homebrew/Cellar/libarchive/3.7.3 --flint-dir=/opt/homebrew/Cellar/flint/3.1.0 --cblas-dir=/opt/homebrew/Cellar/openblas/0.3.27 --prefix=$HOME/install/sdpb-master
 
 ### Compile and install
 

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/restore_bigint_from_residues.hxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/restore_bigint_from_residues.hxx
@@ -5,7 +5,6 @@
 #include "sdpb_util/assert.hxx"
 
 #include <El.hpp>
-#include <flint/nmod.h>
 
 inline void
 restore_bigint_from_residues(const Residue_Matrices_Window<double> &window,

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/fmpz/Fmpz_Comb.cxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/fmpz/Fmpz_Comb.cxx
@@ -1,10 +1,10 @@
-#include <flint/ulong_extras.h>
-#include <El.hpp>
-#include <flint/nmod.h>
-
 #include "Fmpz_Comb.hxx"
 
 #include "sdpb_util/assert.hxx"
+
+#include <flint/ulong_extras.h>
+
+#include <El.hpp>
 
 // TODO explain all parameters!
 namespace

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/fmpz/Fmpz_Comb.hxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/fmpz/Fmpz_Comb.hxx
@@ -1,8 +1,19 @@
 #pragma once
 
 #include <flint/fmpz.h>
-#include <vector>
+// In FLINT 2.8.5, part of nmod_vec.h was extracted to nmod.h
+// See:
+// https://github.com/davidsd/sdpb/issues/234
+// https://github.com/flintlib/flint/pull/1041
+#if __FLINT_RELEASE >= 20805
+#include <flint/nmod.h>
+#else
+#include <flint/nmod_vec.h>
+#endif
+
 #include <boost/noncopyable.hpp>
+
+#include <vector>
 
 // adopted from FLINT, fmpz_mat/mul_blas.c
 // TODO: rename arguments and add description to make the code readable

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/fmpz/fmpz_mul_blas_util.hxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/fmpz/fmpz_mul_blas_util.hxx
@@ -1,12 +1,9 @@
 #pragma once
 
 #include "Fmpz_Comb.hxx"
-#include "fmpz_BigFloat_convert.hxx"
-#include "sdpb_util/Shared_Window_Array.hxx"
 #include "sdpb_util/assert.hxx"
 
 #include <El.hpp>
-#include <flint/nmod.h>
 
 // Code adopted from FLINT library, mat_mul_blas.c
 

--- a/test/src/integration_tests/util/diff_sdpb_out.cxx
+++ b/test/src/integration_tests/util/diff_sdpb_out.cxx
@@ -224,7 +224,8 @@ namespace
             if(a_key == "block_name")
               continue;
             // Errors may differ as they approach zero
-            if(a_key == "P-err" || a_key == "p-err" || a_key == "D-err")
+            if(a_key == "P-err" || a_key == "p-err" || a_key == "D-err"
+               || a_key == "R-err")
               continue;
 
             CAPTURE(a_key);

--- a/test/src/integration_tests/util/diff_sdpb_out.cxx
+++ b/test/src/integration_tests/util/diff_sdpb_out.cxx
@@ -223,10 +223,6 @@ namespace
             // for iteration=1, block_name="block_2" for format=json and block_name="block_19" for format=bin
             if(a_key == "block_name")
               continue;
-            // Errors may differ as they approach zero
-            if(a_key == "P-err" || a_key == "p-err" || a_key == "D-err"
-               || a_key == "R-err")
-              continue;
 
             CAPTURE(a_key);
             CAPTURE(a_value_str);
@@ -234,6 +230,22 @@ namespace
 
             El::BigFloat a_value = a_value_str;
             El::BigFloat b_value = b_value_str;
+
+            // Errors may differ as they approach zero,
+            // so we do not compare small values
+            if(a_key == "P-err" || a_key == "p-err" || a_key == "D-err"
+               || a_key == "R-err")
+              {
+                auto prec = Test_Util::REQUIRE_Equal::diff_precision > 0
+                              ? Test_Util::REQUIRE_Equal::diff_precision
+                              : El::gmp::Precision();
+                // Trying to be conservative, otherwise skydiving test fails:
+                prec /= 2;
+                const auto abs_eps = El::BigFloat(1) >>= prec;
+                if(Abs(a_value) + Abs(b_value) < abs_eps)
+                  continue;
+              }
+
             DIFF(a_value, b_value);
           }
       }

--- a/waf-tools/boost.py
+++ b/waf-tools/boost.py
@@ -88,7 +88,7 @@ boost::stacktrace::stacktrace();
     if not boost_stacktrace_lib_found:
         for boost_stacktrace_lib in ['boost_stacktrace_backtrace', 'boost_stacktrace_addr2line',
                                      'boost_stacktrace_basic']:
-            if conf.check_cxx(msg=f'Checking for {boost_stacktrace_lib}',
+            if conf.check_cxx(msg='Checking for ' + boost_stacktrace_lib,
                               fragment="""
     #include <boost/stacktrace.hpp>
     int main()

--- a/waf-tools/flint.py
+++ b/waf-tools/flint.py
@@ -58,7 +58,7 @@ int main()
                           libpath=flint_libdir,
                           rpath=flint_libdir,
                           lib=flint_libs,
-                          use=['cxx17', 'gmpxx']):
+                          use=['cxx17', 'gmpxx', 'mpfr', 'cblas']):
         conf.fatal("Could not find flint")
 
 

--- a/wscript
+++ b/wscript
@@ -4,7 +4,7 @@ import os, subprocess
 def options(opt):
     opt.load(['compiler_cxx', 'gnu_dirs'])
     opt.load(
-        ['cxx17', 'boost', 'gmpxx', 'mpfr', 'elemental', 'libxml2', 'rapidjson', 'libarchive', 'flint', 'cblas'],
+        ['cxx17', 'boost', 'gmpxx', 'mpfr', 'elemental', 'libxml2', 'rapidjson', 'libarchive', 'cblas', 'flint'],
         tooldir='./waf-tools')
 
 
@@ -13,7 +13,7 @@ def configure(conf):
         conf.environ['CXX'] = 'mpicxx'
 
     conf.load(['compiler_cxx', 'gnu_dirs', 'cxx17', 'boost', 'gmpxx', 'mpfr',
-               'elemental', 'libxml2', 'rapidjson', 'libarchive', 'flint', 'cblas'])
+               'elemental', 'libxml2', 'rapidjson', 'libarchive', 'cblas', 'flint'])
     conf.load('clang_compilation_database', tooldir='./waf-tools')
 
     conf.env.git_version = subprocess.check_output('git describe --tags --always --dirty', universal_newlines=True,


### PR DESCRIPTION
 - Fix #236
 - Fix #234
 - Fix #235
Updated FLINT image, added workaround to documentation
- Update MacBook installation instructions.
- In tests for iterations.json, compare `D-err`, `P-err`, `p-err` and `R-err` only if they are not too close to zero.
- Fix `./waf configure` fail on CircleCI due to missing `mpfr` and `cblas` dependencies.
- Make `waf-tools/boost.py` Python2 compatible