### PR TITLE
Update docs for FLINT + minor configuration changes

### DIFF
--- a/Install.md
+++ b/Install.md
@@ -94,12 +94,14 @@ manager such as [Homebrew](https://brew.sh).
         git clone https://github.com/flintlib/flint.git
         cd flint
         ./bootstrap.sh
-        ./configure --disable-static --enable-assert --prefix=$HOME/install
+        ./configure --disable-static --prefix=$HOME/install
         make
         make check
         make install
         cd ..
 
+   If you have GMP 6.2.0 or earlier, you should use FLINT 3.0.1 or earlier (`git checkout v3.0.1`) and run `configure` with `--disable-gmp-internals` flag to prevent `mpn_gcd_11 not found` error.
+   
    See [FLINT documentation](https://flintlib.org/doc/building.html) for installation instructions.
 
 6. Download SDPB

--- a/Install.md
+++ b/Install.md
@@ -38,7 +38,7 @@ SDPB requires
 
 - [libarchive](https://github.com/libarchive/libarchive)
 
-- [FLINT](https://github.com/flintlib/flint)
+- [FLINT](https://github.com/flintlib/flint) (2.8.0 or later)
 
 SDPB has only been tested on Linux (Debian buster and Centos 7).  On
 Centos 7, the system compiler (gcc 4.8.5) is too old to support

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -281,6 +281,22 @@ See more details in https://github.com/davidsd/sdpb/issues/235.
 This may happen on some filesystems if SDP contains too many block files. Run `pmp2sdp` with `--zip` flag to put
 everything into a single zip archive.
 
+### OpenBLAS fails to create threads
+
+```
+OpenBLAS blas_thread_init: pthread_create failed for thread 15 of 32: Resource temporarily unavailable
+```
+
+Each BLAS call in SDPB should be single-threaded.
+To ensure that, disable threading by setting environment variable
+```
+export OPENBLAS_NUM_THREADS=1
+```
+and/or
+```
+export OMP_NUM_THREADS=1
+```
+
 ### Spectrum does not find zeros
 
 Try to set `--threshold` option for `spectrum` larger than `--dualityGapThreshold` for `sdpb`.

--- a/docs/site_installs/Caltech.md
+++ b/docs/site_installs/Caltech.md
@@ -77,12 +77,11 @@ should compile on a login node.
 
     git clone https://github.com/flintlib/flint.git
     cd flint
-    ./bootstrap.sh    
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=mpicc -DCMAKE_INSTALL_PREFIX=$HOME/install -DBUILD_SHARED_LIBS=ON
-    cmake --build . --target install
-    cd ../..
+    ./bootstrap.sh
+    ./configure CC=mpicc CXX=mpicxx --disable-static --with-gmp=/central/software9/spack/opt/spack/linux-rhel9-x86_64/gcc-13.2.0/gmp-6.2.1-lcnhysea5isaes4r547jt5nw2qru5ab7 --with-mpfr=/central/software9/spack/opt/spack/linux-rhel9-x86_64/gcc-13.2.0/mpfr-4.2.0-yy2fkq564g7urkswawmdk66vpw7ufkkh --prefix=$HOME/install 
+    make
+    make check 
+    make install
 
 ## RapidJSON
     git clone https://github.com/Tencent/rapidjson.git

--- a/docs/site_installs/Caltech.md
+++ b/docs/site_installs/Caltech.md
@@ -78,7 +78,7 @@ should compile on a login node.
     git clone https://github.com/flintlib/flint.git
     cd flint
     ./bootstrap.sh
-    ./configure CC=mpicc CXX=mpicxx --disable-static --with-gmp=/central/software9/spack/opt/spack/linux-rhel9-x86_64/gcc-13.2.0/gmp-6.2.1-lcnhysea5isaes4r547jt5nw2qru5ab7 --with-mpfr=/central/software9/spack/opt/spack/linux-rhel9-x86_64/gcc-13.2.0/mpfr-4.2.0-yy2fkq564g7urkswawmdk66vpw7ufkkh --prefix=$HOME/install 
+    ./configure CC=mpicc CXX=mpicxx --disable-static --with-gmp=`pkg-config --variable=prefix gmp` --with-mpfr=`pkg-config --variable=prefix mpfr`--prefix=$HOME/install 
     make
     make check 
     make install
@@ -97,7 +97,7 @@ should compile on a login node.
     cd ../..
 
 ## sdpb
-    CXX=mpicxx ./waf configure --elemental-dir=$HOME/install --rapidjson-dir=$HOME/install --libarchive-dir=/central/software9/spack/opt/spack/linux-rhel9-x86_64/gcc-13.2.0/libarchive-3.7.1-bzt555vawhwq2akdnvmilrsi5ocxdhvj --gmpxx-dir=/central/software9/spack/opt/spack/linux-rhel9-x86_64/gcc-13.2.0/gmp-6.2.1-lcnhysea5isaes4r547jt5nw2qru5ab7 --mpfr-dir=/central/software/mpfr/4.0.2 --flint-dir=$HOME/install --cblas-dir=/central/software9/spack/opt/spack/linux-rhel9-x86_64/gcc-13.2.0/openblas-0.3.23-3csynnoa2r6ctx3khqe5gxye6ukno3mu --prefix=$HOME/install/sdpb-master
+    CXX=mpicxx ./waf configure --elemental-dir=$HOME/install --rapidjson-dir=$HOME/install --libarchive-dir=`pkg-config --variable=prefix libarchive` --gmpxx-dir=`pkg-config --variable=prefix gmp` --mpfr-dir=`pkg-config --variable=prefix mpfr` --flint-dir=$HOME/install --cblas-incdir=`pkg-config --variable=includedir openblas` --cblas-libdir=`pkg-config --variable=libdir openblas` --prefix=$HOME/install/sdpb-master
     ./waf # -j 1
     ./test/run_all_tests.sh
     ./waf install

--- a/docs/site_installs/Expanse.md
+++ b/docs/site_installs/Expanse.md
@@ -73,14 +73,16 @@ TODO: on compute nodes compiler fails to find some libs
 
 ## FLINT
 
-    git clone https://github.com/flintlib/flint.git
+    git clone https://github.com/flintlib/flint.git -b v3.0.1
     cd flint
-    ./bootstrap.sh    
-    mkdir build
-    cd build
-    cmake .. -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=mpicc -DCMAKE_INSTALL_PREFIX=$HOME/install -DBUILD_SHARED_LIBS=ON
-    cmake --build . --target install
-    cd ../..
+    ./bootstrap.sh
+    ./configure CC=mpicc CXX=mpicxx --disable-static --disable-gmp-internals --prefix=$HOME/install 
+    make
+    make check 
+    make install
+
+Note that you have to checkout `v3.0.1` because starting from v3.1.0 FLINT requires GMP 6.2.1 or later.
+The flag `--disable-gmp-internals` is required to prevent `mpn_gcd_11 not found` error.
 
 ## libarchive
 

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/BigInt_Shared_Memory_Syrk_Context.cxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/BigInt_Shared_Memory_Syrk_Context.cxx
@@ -355,8 +355,16 @@ BigInt_Shared_Memory_Syrk_Context::BigInt_Shared_Memory_Syrk_Context(
            DEBUG_STRING(max_shared_memory_bytes));
   }
 
-  // Disable BLAS threading explicitly, each rank should work single-threaded
+// detect OpenBLAS using any OpenBLAS-specific macro from cblas.h
+#ifdef OPENBLAS_THREAD
+  // Disable BLAS threading explicitly, each rank should work single-threaded.
+  // If this does not work, try also setting environment variables:
+  // export OPENBLAS_NUM_THREADS=1
+  // or also:
+  // export OMP_NUM_THREADS=1
   openblas_set_num_threads(1);
+#endif
+  // TODO: disable threading for other CBLAS implementations too.
 }
 
 El::Int BigInt_Shared_Memory_Syrk_Context::input_group_height_per_prime() const

--- a/waf-tools/flint.py
+++ b/waf-tools/flint.py
@@ -42,16 +42,17 @@ def configure(conf):
     if not conf.check_cxx(msg="Checking for flint",
                           fragment='''
 #include "flint/flint.h"
-#include "flint/arb.h"
+#include "flint/fmpz.h"
+#include <vector>
 
 int main()
 {
-    arb_t x;
-    arb_init(x);
-    arb_const_pi(x, 50 * 3.33);
-    arb_printn(x, 50, 0); flint_printf("");
-    flint_printf("Computed with FLINT-%s", flint_version);
-    arb_clear(x);
+    static_assert(__FLINT_RELEASE >= 20800, "FLINT 2.8.0 or later required, current version: " FLINT_VERSION);
+
+    std::vector<mp_limb_t> primes{2, 3, 5};
+    fmpz_comb_t comb;
+    fmpz_comb_init(comb, primes.data(), primes.size());
+    flint_printf("Computed with FLINT-%s", FLINT_VERSION);
 }''',
                           includes=flint_incdir,
                           uselib_store='flint',


### PR DESCRIPTION
- Require FLINT 2.8.0 or later
Close #238, won't fix it.
- Update FLINT installation instructions
- Add workaround for disabling OpenBLAS threads
For some reason, `openblas_set_num_threads(1)` does not always work. In that case, one has to set environment variables `OPENBLAS_NUM_THREADS=1` and/or `OMP_NUM_THREADS=1`.
- Call `openblas_set_num_threads(1)` only when OpenBLAS is detected.
Otherwise, compilation fails for other BLAS implementations (e.g. FlexiBLAS)