### PR TITLE
Fix #242 Get dependency paths from pkg-config

### DIFF
--- a/docs/site_installs/Caltech.md
+++ b/docs/site_installs/Caltech.md
@@ -97,7 +97,8 @@ should compile on a login node.
     cd ../..
 
 ## sdpb
-    CXX=mpicxx ./waf configure --elemental-dir=$HOME/install --rapidjson-dir=$HOME/install --libarchive-dir=`pkg-config --variable=prefix libarchive` --gmpxx-dir=`pkg-config --variable=prefix gmp` --mpfr-dir=`pkg-config --variable=prefix mpfr` --flint-dir=$HOME/install --cblas-incdir=`pkg-config --variable=includedir openblas` --cblas-libdir=`pkg-config --variable=libdir openblas` --prefix=$HOME/install/sdpb-master
+    CXX=mpicxx ./waf configure --libarchive-dir=`pkg-config --variable=prefix libarchive` --elemental-dir=$HOME/install --rapidjson-dir=$HOME/install --flint-dir=$HOME/install 
+    --prefix=$HOME/install/sdpb-master
     ./waf # -j 1
     ./test/run_all_tests.sh
     ./waf install

--- a/docs/site_installs/Imperial.md
+++ b/docs/site_installs/Imperial.md
@@ -125,7 +125,7 @@ We have to build GMP manually: FLINT requires at least MPFR 4.1.0, but only MPFR
 
     git clone https://github.com/davidsd/sdpb.git
     cd sdpb 
-    python3 ./waf configure --gmpxx-dir=$HOME/install --mpfr-dir=$HOME/install --elemental-dir=$HOME/install --rapidjson-dir=$HOME/install --libarchive-dir=$HOME/install --flint-dir=$HOME/install --cblas-incdir=/usr/include/openblas --cblas-libdir=/usr/lib64 --prefix=$HOME/install/sdpb-master
+    python3 ./waf configure --gmpxx-dir=$HOME/install --mpfr-dir=$HOME/install --elemental-dir=$HOME/install --rapidjson-dir=$HOME/install --libarchive-dir=$HOME/install --flint-dir=$HOME/install --prefix=$HOME/install/sdpb-master
     python3 ./waf # -j 1
     ./test/run_all_tests.sh mpirun
     python3 ./waf install

--- a/src/sdpb_util/Number_State.hxx
+++ b/src/sdpb_util/Number_State.hxx
@@ -4,7 +4,7 @@
 
 #include <El.hpp>
 
-#include <libxml2/libxml/parser.h>
+#include <libxml/parser.h>
 #include <vector>
 #include <sstream>
 #include <stdexcept>

--- a/src/sdpb_util/Vector_State.hxx
+++ b/src/sdpb_util/Vector_State.hxx
@@ -2,7 +2,7 @@
 
 #include "assert.hxx"
 
-#include <libxml2/libxml/parser.h>
+#include <libxml/parser.h>
 #include <vector>
 #include <string>
 #include <stdexcept>

--- a/waf-tools/boost.py
+++ b/waf-tools/boost.py
@@ -1,6 +1,9 @@
 #! /usr/bin/env python
 # encoding: utf-8
 
+from check_config import check_config
+
+
 def configure(conf):
     # Find Boost
     import os
@@ -50,8 +53,8 @@ def configure(conf):
     # link to boost_stacktrace library instead of header-only compilation:
     boost_defines = ['BOOST_STACKTRACE_LINK'] if boost_stacktrace_lib_found else []
 
-    conf.check_cxx(msg="Checking for Boost",
-                   fragment="""#include <boost/iostreams/filter/gzip.hpp>
+    check_config(conf,
+                 fragment="""#include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/device/file.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -72,13 +75,12 @@ boost::serialization::version_type version;
 boost::stacktrace::stacktrace();
 }
 """,
-                   includes=boost_incdir,
-                   uselib_store='boost',
-                   libpath=boost_libdir,
-                   rpath=boost_libdir,
-                   lib=boost_libs,
-                   use=['cxx17'],
-                   defines=boost_defines)
+                 includes=boost_incdir,
+                 uselib_store='boost',
+                 libpath=boost_libdir,
+                 lib=boost_libs,
+                 use=['cxx17'],
+                 defines=boost_defines)
 
     # If boost_stacktrace library not defined by user, try linking to one of the libraries
     # listed in https://www.boost.org/doc/libs/1_84_0/doc/html/stacktrace/configuration_and_build.html
@@ -88,22 +90,22 @@ boost::stacktrace::stacktrace();
     if not boost_stacktrace_lib_found:
         for boost_stacktrace_lib in ['boost_stacktrace_backtrace', 'boost_stacktrace_addr2line',
                                      'boost_stacktrace_basic']:
-            if conf.check_cxx(msg='Checking for ' + boost_stacktrace_lib,
-                              fragment="""
+            if check_config(conf,
+                            msg='  Checking for ' + boost_stacktrace_lib,
+                            fragment="""
     #include <boost/stacktrace.hpp>
     int main()
     {
       boost::stacktrace::stacktrace();
     }
     """,
-                              includes=boost_incdir,
-                              uselib_store='boost',
-                              libpath=boost_libdir,
-                              rpath=boost_libdir,
-                              lib=boost_libs + [boost_stacktrace_lib],
-                              use=['cxx17'],
-                              defines='BOOST_STACKTRACE_LINK',
-                              mandatory=False):
+                            includes=boost_incdir,
+                            uselib_store='boost',
+                            libpath=boost_libdir,
+                            lib=boost_libs + [boost_stacktrace_lib],
+                            use=['cxx17'],
+                            defines='BOOST_STACKTRACE_LINK',
+                            mandatory=False):
                 break
 
 

--- a/waf-tools/cblas.py
+++ b/waf-tools/cblas.py
@@ -1,9 +1,13 @@
 #! /usr/bin/env python
 # encoding: utf-8
 
+from check_config import check_config
+
+
 def configure(conf):
     # Find cblas
     import os
+
     if not conf.options.cblas_incdir:
         for libname in ['CBLAS', 'OPENBLAS']:
             for suffix in ['_INCLUDE', '_INCLUDE_DIR', '_INC_DIR', '_INCDIR']:
@@ -42,25 +46,24 @@ def configure(conf):
     else:
         cblas_libs = ['openblas']
 
-    if not conf.check_cxx(msg="Checking for CBLAS",
-                          fragment='''
+    check_config(conf,
+                 fragment='''
 #include "cblas.h"
 
 int main()
 {
-  int m=10,n=10,k=10;
-  double x[m*k];
-  double y[k*n];
-  double result[m*n];
-  cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, m, n, k, 1.0, x, k, y, n, 0.0, result, n);
+    int m=10,n=10,k=10;
+    double x[m*k];
+    double y[k*n];
+    double result[m*n];
+    cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, m, n, k, 1.0, x, k, y, n, 0.0, result, n);
 }''',
-                          includes=cblas_incdir,
-                          uselib_store='cblas',
-                          libpath=cblas_libdir,
-                          rpath=cblas_libdir,
-                          lib=cblas_libs,
-                          use=['cxx17']):
-        conf.fatal("Could not find CBLAS")
+                 includes=cblas_incdir,
+                 uselib_store='cblas',
+                 libpath=cblas_libdir,
+                 lib=cblas_libs,
+                 packages=cblas_libs,
+                 use=['cxx17'])
 
 
 def options(opt):

--- a/waf-tools/check_config.py
+++ b/waf-tools/check_config.py
@@ -1,0 +1,56 @@
+#! /usr/bin/env python
+# encoding: utf-8
+
+def check_pkg_config(conf, package, uselib_store, fragment, use=None, msg_prefix=None, **kwargs):
+    msg_prefix = msg_prefix or ''
+    if not conf.check_cfg(msg=msg_prefix + 'Searching for ' + package + ' in pkg-config',
+                          path='pkg-config',
+                          args='--libs --cflags',
+                          package=package,
+                          uselib_store=uselib_store,
+                          **kwargs):
+        return False
+    # check_cfg() does not support 'fragment' argument,
+    # so we have to check compilation separately via check_cxx()
+    return conf.check_cxx(msg=msg_prefix + 'Checking ' + package + ' compilation',
+                          fragment=fragment,
+                          use=(use or []) + [uselib_store],
+                          **kwargs)
+
+
+def check_config(conf, fragment, uselib_store, includes, libpath, lib, msg=None, packages=None, use=None,
+                 mandatory=True,
+                 **kwargs):
+    # pkg-config package names
+    if packages is None:
+        packages = [uselib_store]
+    # extra dependencies, e.g. cxx17
+    if use is None:
+        use = []
+
+    if conf.check_cxx(msg=msg or 'Checking for ' + uselib_store,
+                      fragment=fragment,
+                      includes=includes,
+                      uselib_store=uselib_store,
+                      libpath=libpath,
+                      rpath=libpath,
+                      lib=lib,
+                      use=use,
+                      mandatory=False,
+                      **kwargs):
+        return True
+
+    for package in packages:
+        if check_pkg_config(conf,
+                            fragment=fragment,
+                            package=package,
+                            uselib_store=uselib_store,
+                            use=use,
+                            mandatory=False,
+                            msg_prefix='  ',
+                            **kwargs):
+            return True
+
+    if mandatory:
+        conf.fatal('Could not find ' + uselib_store)
+    return False

--- a/waf-tools/check_config.py
+++ b/waf-tools/check_config.py
@@ -10,11 +10,20 @@ def check_pkg_config(conf, package, uselib_store, fragment, use=None, msg_prefix
                           uselib_store=uselib_store,
                           **kwargs):
         return False
+
     # check_cfg() does not support 'fragment' argument,
     # so we have to check compilation separately via check_cxx()
+
+    # We also set rpath=libpath, same as we do in check_config() below
+    # You can find LIBPATH values (set by conf.check_cfg)
+    # in build/c4che/_cache.py, e.g.
+    # LIBPATH_cblas = ['/usr/lib/x86_64-linux-gnu/openblas-pthread/']
+    libpath = getattr(conf.env, 'LIBPATH_' + uselib_store, None)
     return conf.check_cxx(msg=msg_prefix + 'Checking ' + package + ' compilation',
                           fragment=fragment,
+                          rpath=libpath,
                           use=(use or []) + [uselib_store],
+                          uselib_store=uselib_store,
                           **kwargs)
 
 

--- a/waf-tools/elemental.py
+++ b/waf-tools/elemental.py
@@ -1,57 +1,58 @@
 #! /usr/bin/env python
 # encoding: utf-8
 
-def configure(conf):
-    def get_param(varname,default):
-        return getattr(Options.options,varname,'')or default
+from check_config import check_config
 
+
+def configure(conf):
     import os
+
     # Find Elemental
     if conf.options.elemental_dir:
         if not conf.options.elemental_incdir:
-            conf.options.elemental_incdir=conf.options.elemental_dir + "/include"
+            conf.options.elemental_incdir = conf.options.elemental_dir + "/include"
         if not conf.options.elemental_libdir:
-            lib=conf.options.elemental_dir + "/lib"
+            lib = conf.options.elemental_dir + "/lib"
             if os.path.isdir(lib):
-                conf.options.elemental_libdir=lib
-            lib64=conf.options.elemental_dir + "/lib64"
+                conf.options.elemental_libdir = lib
+            lib64 = conf.options.elemental_dir + "/lib64"
             if os.path.isdir(lib64):
                 if conf.options.elemental_libdir:
-                    conf.options.elemental_libdir+=" " + lib64
+                    conf.options.elemental_libdir += " " + lib64
                 else:
-                    conf.options.elemental_libdir=lib64
+                    conf.options.elemental_libdir = lib64
 
     if conf.options.elemental_incdir:
-        elemental_incdir=conf.options.elemental_incdir.split()
+        elemental_incdir = conf.options.elemental_incdir.split()
     else:
-        elemental_incdir=[]
+        elemental_incdir = []
     if conf.options.elemental_libdir:
-        elemental_libdir=conf.options.elemental_libdir.split()
+        elemental_libdir = conf.options.elemental_libdir.split()
     else:
-        elemental_libdir=[]
+        elemental_libdir = []
 
     if conf.options.elemental_libs:
-        elemental_libs=conf.options.elemental_libs.split()
+        elemental_libs = conf.options.elemental_libs.split()
     else:
-        elemental_libs=['El', 'pmrrr', 'ElSuiteSparse' ]
+        elemental_libs = ['El', 'pmrrr', 'ElSuiteSparse']
 
-    conf.check_cxx(msg="Checking for Elemental",
-                   fragment="#include <El.hpp>\nint main(int argc, char* argv[]) {El::Environment env( argc, argv ); El::BigFloat big;}\n",
-                   includes=elemental_incdir,
-                   uselib_store='elemental',
-                   libpath=elemental_libdir,
-                   rpath=elemental_libdir,
-                   lib=elemental_libs,
-                   use=['cxx17','gmpxx'])
+    check_config(conf,
+                 fragment="#include <El.hpp>\nint main(int argc, char* argv[]) {El::Environment env( argc, argv ); El::BigFloat big;}\n",
+                 includes=elemental_incdir,
+                 uselib_store='elemental',
+                 libpath=elemental_libdir,
+                 lib=elemental_libs,
+                 use=['cxx17', 'gmpxx', 'mpfr'])
+
 
 def options(opt):
-    elemental=opt.add_option_group('Elemental Options')
+    elemental = opt.add_option_group('Elemental Options')
     elemental.add_option('--elemental-dir',
-                   help='Base directory where elemental is installed')
+                         help='Base directory where elemental is installed')
     elemental.add_option('--elemental-incdir',
-                   help='Directory where elemental include files are installed')
+                         help='Directory where elemental include files are installed')
     elemental.add_option('--elemental-libdir',
-                   help='Directory where elemental library files are installed')
+                         help='Directory where elemental library files are installed')
     elemental.add_option('--elemental-libs',
-                   help='Names of the elemental libraries without prefix or suffix\n'
-                   '(e.g. "El pmrrr ElSuiteSparse")')
+                         help='Names of the elemental libraries without prefix or suffix\n'
+                              '(e.g. "El pmrrr ElSuiteSparse")')

--- a/waf-tools/flint.py
+++ b/waf-tools/flint.py
@@ -1,9 +1,13 @@
 #! /usr/bin/env python
 # encoding: utf-8
 
+from check_config import check_config
+
+
 def configure(conf):
-    # Find Libarchive
+    # Find FLINT
     import os
+
     if not conf.options.flint_incdir:
         for d in ['FLINT_INCLUDE', 'FLINT_INCLUDE_DIR', 'FLINT_INC_DIR']:
             env_dir = os.getenv(d)
@@ -39,8 +43,8 @@ def configure(conf):
     else:
         flint_libs = ['flint']
 
-    if not conf.check_cxx(msg="Checking for flint",
-                          fragment='''
+    check_config(conf,
+                 fragment='''
 #include "flint/flint.h"
 #include "flint/fmpz.h"
 #include <vector>
@@ -54,13 +58,11 @@ int main()
     fmpz_comb_init(comb, primes.data(), primes.size());
     flint_printf("Computed with FLINT-%s", FLINT_VERSION);
 }''',
-                          includes=flint_incdir,
-                          uselib_store='flint',
-                          libpath=flint_libdir,
-                          rpath=flint_libdir,
-                          lib=flint_libs,
-                          use=['cxx17', 'gmpxx', 'mpfr', 'cblas']):
-        conf.fatal("Could not find flint")
+                 includes=flint_incdir,
+                 uselib_store='flint',
+                 libpath=flint_libdir,
+                 lib=flint_libs,
+                 use=['cxx17', 'gmpxx', 'mpfr', 'cblas'])
 
 
 def options(opt):

--- a/waf-tools/gmpxx.py
+++ b/waf-tools/gmpxx.py
@@ -1,78 +1,85 @@
 #! /usr/bin/env python
 # encoding: utf-8
 
-import os
+from check_config import check_config
+
 
 def configure(conf):
-    def get_param(varname,default):
-        return getattr(Options.options,varname,'')or default
+    import os
 
     if not conf.options.gmpxx_incdir:
-        for d in ['GMP_INCLUDE','GMPXX_INCLUDE','GMP_INCLUDE_DIR',
-                  'GMPXX_INCLUDE_DIR','GMP_INC_DIR','GMPXX_INC_DIR']:
-            env_dir=os.getenv(d)
+        for d in ['GMP_INCLUDE', 'GMPXX_INCLUDE', 'GMP_INCLUDE_DIR',
+                  'GMPXX_INCLUDE_DIR', 'GMP_INC_DIR', 'GMPXX_INC_DIR']:
+            env_dir = os.getenv(d)
             if env_dir:
                 conf.to_log('Setting gmpxx_incdir using environment variable: ' + d + '=' + env_dir)
-                conf.options.gmpxx_incdir=env_dir
-                
+                conf.options.gmpxx_incdir = env_dir
+
     if not conf.options.gmpxx_libdir:
-        for d in ['GMP_LIB','GMPXX_LIB','GMP_LIB_DIR','GMPXX_LIB_DIR']:
-            env_dir=os.getenv(d)
+        for d in ['GMP_LIB', 'GMPXX_LIB', 'GMP_LIB_DIR', 'GMPXX_LIB_DIR']:
+            env_dir = os.getenv(d)
             if env_dir:
                 conf.to_log('Setting gmpxx_libdir using environment variable: ' + d + '=' + env_dir)
-                conf.options.gmpxx_libdir=env_dir
+                conf.options.gmpxx_libdir = env_dir
 
     if not conf.options.gmpxx_dir:
-        for d in ['GMP_DIR','GMPXX_DIR']:
-            env_dir=os.getenv(d)
+        for d in ['GMP_DIR', 'GMPXX_DIR']:
+            env_dir = os.getenv(d)
             if env_dir:
                 conf.to_log('Setting gmpxx_dir using environment variable: ' + d + '=' + env_dir)
-                conf.options.gmpxx_dir=env_dir
-                
+                conf.options.gmpxx_dir = env_dir
+
     # Find GMPXX
     if conf.options.gmpxx_dir:
         conf.to_log('Using gmpxx_dir: ' + conf.options.gmpxx_dir)
         if not conf.options.gmpxx_incdir:
             conf.to_log('Setting gmpxx_incdir using gmpxx_dir: ' + conf.options.gmpxx_dir)
-            conf.options.gmpxx_incdir=conf.options.gmpxx_dir + "/include"
+            conf.options.gmpxx_incdir = conf.options.gmpxx_dir + "/include"
         if not conf.options.gmpxx_libdir:
             conf.to_log('Setting gmpxx_libdir using gmpxx_dir: ' + conf.options.gmpxx_dir)
-            conf.options.gmpxx_libdir=conf.options.gmpxx_dir + "/lib"
+            conf.options.gmpxx_libdir = conf.options.gmpxx_dir + "/lib"
 
     if conf.options.gmpxx_incdir:
         conf.to_log('Using gmpxx_incdir: ' + conf.options.gmpxx_incdir)
-        gmpxx_incdir=conf.options.gmpxx_incdir.split()
+        gmpxx_incdir = conf.options.gmpxx_incdir.split()
     else:
-        gmpxx_incdir=[]
+        gmpxx_incdir = []
     if conf.options.gmpxx_libdir:
         conf.to_log('Using gmpxx_libdir: ' + conf.options.gmpxx_libdir)
-        gmpxx_libdir=conf.options.gmpxx_libdir.split()
+        gmpxx_libdir = conf.options.gmpxx_libdir.split()
     else:
-        gmpxx_libdir=[]
+        gmpxx_libdir = []
 
     if conf.options.gmpxx_libs:
         conf.to_log('Using gmpxx_libs: ' + conf.options.gmpxx_libs)
-        gmpxx_libs=conf.options.gmpxx_libs.split()
+        gmpxx_libs = conf.options.gmpxx_libs.split()
     else:
-        gmpxx_libs=['gmpxx','gmp']
+        gmpxx_libs = ['gmpxx', 'gmp']
 
-    conf.check_cxx(msg="Checking for GMPXX",
-                   header_name='gmpxx.h',
-                   includes=gmpxx_incdir,
-                   uselib_store='gmpxx',
-                   libpath=gmpxx_libdir,
-                   rpath=gmpxx_libdir,
-                   lib=gmpxx_libs,
-                   use=['cxx17'])
+    check_config(conf,
+                 fragment='''
+#include <gmpxx.h>
+int main()
+{
+    mpf_t qf;
+    mpf_init(qf);
+}
+                 ''',
+                 includes=gmpxx_incdir,
+                 uselib_store='gmpxx',
+                 libpath=gmpxx_libdir,
+                 lib=gmpxx_libs,
+                 use=['cxx17'])
+
 
 def options(opt):
-    gmpxx=opt.add_option_group('GMPXX Options')
+    gmpxx = opt.add_option_group('GMPXX Options')
     gmpxx.add_option('--gmpxx-dir',
-                   help='Base directory where gmpxx is installed')
+                     help='Base directory where gmpxx is installed')
     gmpxx.add_option('--gmpxx-incdir',
-                   help='Directory where gmpxx include files are installed')
+                     help='Directory where gmpxx include files are installed')
     gmpxx.add_option('--gmpxx-libdir',
-                   help='Directory where gmpxx library files are installed')
+                     help='Directory where gmpxx library files are installed')
     gmpxx.add_option('--gmpxx-libs',
-                   help='Names of the gmpxx libraries without prefix or suffix\n'
-                   '(e.g. "gmpxx")')
+                     help='Names of the gmpxx libraries without prefix or suffix\n'
+                          '(e.g. "gmpxx")')

--- a/waf-tools/libarchive.py
+++ b/waf-tools/libarchive.py
@@ -1,45 +1,49 @@
 #! /usr/bin/env python
 # encoding: utf-8
 
+from check_config import check_config
+
+
 def configure(conf):
     # Find Libarchive
     import os
+
     if not conf.options.libarchive_incdir:
-        for d in ['LIBARCHIVE_INCLUDE','LIBARCHIVE_INCLUDE_DIR','LIBARCHIVE_INC_DIR']:
-            env_dir=os.getenv(d)
+        for d in ['LIBARCHIVE_INCLUDE', 'LIBARCHIVE_INCLUDE_DIR', 'LIBARCHIVE_INC_DIR']:
+            env_dir = os.getenv(d)
             if env_dir:
                 conf.to_log('Setting libarchive_incdir using environment variable: ' + d + '=' + env_dir)
-                conf.options.libarchive_incdir=env_dir
-                
+                conf.options.libarchive_incdir = env_dir
+
     if not conf.options.libarchive_libdir:
-        for d in ['LIBARCHIVE_LIB','LIBARCHIVE_LIB_DIR']:
-            env_dir=os.getenv(d)
+        for d in ['LIBARCHIVE_LIB', 'LIBARCHIVE_LIB_DIR']:
+            env_dir = os.getenv(d)
             if env_dir:
                 conf.to_log('Setting libarchive_libdir using environment variable: ' + d + '=' + env_dir)
-                conf.options.libarchive_libdir=env_dir
+                conf.options.libarchive_libdir = env_dir
 
     if conf.options.libarchive_dir:
         if not conf.options.libarchive_incdir:
-            conf.options.libarchive_incdir=conf.options.libarchive_dir + "/include"
+            conf.options.libarchive_incdir = conf.options.libarchive_dir + "/include"
         if not conf.options.libarchive_libdir:
-            conf.options.libarchive_libdir=conf.options.libarchive_dir + "/lib"
+            conf.options.libarchive_libdir = conf.options.libarchive_dir + "/lib"
 
     if conf.options.libarchive_incdir:
-        libarchive_incdir=conf.options.libarchive_incdir.split()
+        libarchive_incdir = conf.options.libarchive_incdir.split()
     else:
-        libarchive_incdir=[]
+        libarchive_incdir = []
     if conf.options.libarchive_libdir:
-        libarchive_libdir=conf.options.libarchive_libdir.split()
+        libarchive_libdir = conf.options.libarchive_libdir.split()
     else:
-        libarchive_libdir=[]
+        libarchive_libdir = []
 
     if conf.options.libarchive_libs:
-        libarchive_libs=conf.options.libarchive_libs.split()
+        libarchive_libs = conf.options.libarchive_libs.split()
     else:
-        libarchive_libs=['archive']
+        libarchive_libs = ['archive']
 
-    if not conf.check_cxx(msg="Checking for libarchive",
-                          fragment='''
+    check_config(conf,
+                 fragment='''
 #include <archive.h>
 int main()
 {
@@ -47,23 +51,21 @@ int main()
   archive_read_free(a);
 }
 ''',
-                          includes=libarchive_incdir,
-                          uselib_store='libarchive',
-                          libpath=libarchive_libdir,
-                          rpath=libarchive_libdir,
-                          lib=libarchive_libs,
-                          use=['cxx17']):
-        conf.fatal("Could not find libarchive")
+                 includes=libarchive_incdir,
+                 uselib_store='libarchive',
+                 libpath=libarchive_libdir,
+                 lib=libarchive_libs,
+                 use=['cxx17'])
 
 
 def options(opt):
-    libarchive=opt.add_option_group('Libarchive Options')
+    libarchive = opt.add_option_group('Libarchive Options')
     libarchive.add_option('--libarchive-dir',
-                   help='Base directory where libarchive is installed')
+                          help='Base directory where libarchive is installed')
     libarchive.add_option('--libarchive-incdir',
-                   help='Directory where libarchive include files are installed')
+                          help='Directory where libarchive include files are installed')
     libarchive.add_option('--libarchive-libdir',
-                   help='Directory where libarchive library files are installed')
+                          help='Directory where libarchive library files are installed')
     libarchive.add_option('--libarchive-libs',
-                   help='Names of the libarchive and libarchive libraries without prefix or suffix\n'
-                   '(e.g. "archive")')
+                          help='Names of the libarchive and libarchive libraries without prefix or suffix\n'
+                               '(e.g. "archive")')

--- a/waf-tools/libxml2.py
+++ b/waf-tools/libxml2.py
@@ -1,81 +1,70 @@
 #! /usr/bin/env python
 # encoding: utf-8
 
+from check_config import check_config
+
+
 def configure(conf):
     # Find Libxml2
     import os
+
     if not conf.options.libxml2_incdir:
-        for d in ['LIBXML2_INCLUDE','LIBXML2_INCLUDE_DIR','LIBXML2_INC_DIR']:
-            env_dir=os.getenv(d)
+        for d in ['LIBXML2_INCLUDE', 'LIBXML2_INCLUDE_DIR', 'LIBXML2_INC_DIR']:
+            env_dir = os.getenv(d)
             if env_dir:
                 conf.to_log('Setting libxml2_incdir using environment variable: ' + d + '=' + env_dir)
-                conf.options.libxml2_incdir=env_dir
-                
+                conf.options.libxml2_incdir = env_dir
+
     if not conf.options.libxml2_libdir:
-        for d in ['LIBXML2_LIB','LIBXML2_LIB_DIR']:
-            env_dir=os.getenv(d)
+        for d in ['LIBXML2_LIB', 'LIBXML2_LIB_DIR']:
+            env_dir = os.getenv(d)
             if env_dir:
                 conf.to_log('Setting libxml2_libdir using environment variable: ' + d + '=' + env_dir)
-                conf.options.libxml2_libdir=env_dir
+                conf.options.libxml2_libdir = env_dir
 
     if conf.options.libxml2_dir:
         if not conf.options.libxml2_incdir:
-            conf.options.libxml2_incdir=conf.options.libxml2_dir + "/include"
+            conf.options.libxml2_incdir = conf.options.libxml2_dir + "/include"
         if not conf.options.libxml2_libdir:
-            conf.options.libxml2_libdir=conf.options.libxml2_dir + "/lib"
+            conf.options.libxml2_libdir = conf.options.libxml2_dir + "/lib"
 
     if conf.options.libxml2_incdir:
-        libxml2_incdir=conf.options.libxml2_incdir.split()
+        libxml2_incdir = conf.options.libxml2_incdir.split()
     else:
-        libxml2_incdir=[]
+        libxml2_incdir = []
     if conf.options.libxml2_libdir:
-        libxml2_libdir=conf.options.libxml2_libdir.split()
+        libxml2_libdir = conf.options.libxml2_libdir.split()
     else:
-        libxml2_libdir=[]
+        libxml2_libdir = []
 
     if conf.options.libxml2_libs:
-        libxml2_libs=conf.options.libxml2_libs.split()
+        libxml2_libs = conf.options.libxml2_libs.split()
     else:
-        libxml2_libs=['xml2']
+        libxml2_libs = ['xml2']
 
-    fragment='''
+    check_config(conf,
+                 fragment='''
 #include <libxml/parser.h>
 int main()
 {
   xmlInitParser();
 }
-'''
-
-    if not conf.check_cxx(msg="Checking for libxml2 in default and user-specified paths",
-                          fragment=fragment,
-                          includes=libxml2_incdir,
-                          uselib_store='libxml2',
-                          libpath=libxml2_libdir,
-                          rpath=libxml2_libdir,
-                          lib=libxml2_libs,
-                          mandatory=False):
-        conf.check_cfg(msg='  Searching for libxml-2.0 in pkg-config',
-                       path='pkg-config',
-                       args='--libs --cflags',
-                       package='libxml-2.0',
-                       uselib_store='libxml2',
-                       mandatory=True)
-        # check_cfg() does not support 'fragment' argument,
-        # so we have to check compilation separately via check_cxx()
-        conf.check_cxx(msg='  Checking libxml2 compilation',
-                       fragment=fragment,
-                       use=['libxml2'],
-                       mandatory=True)
+      ''',
+                 includes=libxml2_incdir,
+                 uselib_store='libxml2',
+                 libpath=libxml2_libdir,
+                 lib=libxml2_libs,
+                 packages=['libxml-2.0'])
 
 
 def options(opt):
-    libxml2=opt.add_option_group('Libxml2 Options')
+    libxml2 = opt.add_option_group('Libxml2 Options')
     libxml2.add_option('--libxml2-dir',
-                   help='Base directory where libxml2 is installed')
+                       help='Base directory where libxml2 is installed')
     libxml2.add_option('--libxml2-incdir',
-                   help='Directory where libxml2 include files are installed')
+                       help='Directory where libxml2 include files are installed')
     libxml2.add_option('--libxml2-libdir',
-                   help='Directory where libxml2 library files are installed')
+                       help='Directory where libxml2 library files are installed')
     libxml2.add_option('--libxml2-libs',
-                   help='Names of the libxml2 libraries without prefix or suffix\n'
-                   '(e.g. "xml2")')
+                       help='Names of the libxml2 libraries without prefix or suffix\n'
+                            '(e.g. "xml2")')

--- a/waf-tools/libxml2.py
+++ b/waf-tools/libxml2.py
@@ -38,17 +38,34 @@ def configure(conf):
     else:
         libxml2_libs=['xml2']
 
-    if not conf.check_cxx(msg="Checking for libxml2",
-                          header_name='libxml/parser.h',
+    fragment='''
+#include <libxml/parser.h>
+int main()
+{
+  xmlInitParser();
+}
+'''
+
+    if not conf.check_cxx(msg="Checking for libxml2 in default and user-specified paths",
+                          fragment=fragment,
                           includes=libxml2_incdir,
                           uselib_store='libxml2',
                           libpath=libxml2_libdir,
                           rpath=libxml2_libdir,
                           lib=libxml2_libs,
-                          mandatory=False) and not conf.check_cfg(path='pkg-config', args='--libs --cflags',
-                                                                  package='libxml-2.0', uselib_store='libxml2',
-                                                                  mandatory=False):
-        conf.fatal("Could not find libxml2")
+                          mandatory=False):
+        conf.check_cfg(msg='  Searching for libxml-2.0 in pkg-config',
+                       path='pkg-config',
+                       args='--libs --cflags',
+                       package='libxml-2.0',
+                       uselib_store='libxml2',
+                       mandatory=True)
+        # check_cfg() does not support 'fragment' argument,
+        # so we have to check compilation separately via check_cxx()
+        conf.check_cxx(msg='  Checking libxml2 compilation',
+                       fragment=fragment,
+                       use=['libxml2'],
+                       mandatory=True)
 
 
 def options(opt):

--- a/waf-tools/mpfr.py
+++ b/waf-tools/mpfr.py
@@ -1,76 +1,83 @@
 #! /usr/bin/env python
 # encoding: utf-8
 
-import os
+from check_config import check_config
+
 
 def configure(conf):
-    def get_param(varname,default):
-        return getattr(Options.options,varname,'')or default
+    import os
 
     if not conf.options.mpfr_incdir:
-        for d in ['MPFR_INCLUDE','MPFR_INCLUDE_DIR','MPFR_INC_DIR']:
-            env_dir=os.getenv(d)
+        for d in ['MPFR_INCLUDE', 'MPFR_INCLUDE_DIR', 'MPFR_INC_DIR']:
+            env_dir = os.getenv(d)
             if env_dir:
                 conf.to_log('Setting mpfr_incdir using environment variable: ' + d + '=' + env_dir)
-                conf.options.mpfr_incdir=env_dir
-                
+                conf.options.mpfr_incdir = env_dir
+
     if not conf.options.mpfr_libdir:
-        for d in ['MPFR_LIB','MPFR_LIB_DIR']:
-            env_dir=os.getenv(d)
+        for d in ['MPFR_LIB', 'MPFR_LIB_DIR']:
+            env_dir = os.getenv(d)
             if env_dir:
                 conf.to_log('Setting mpfr_libdir using environment variable: ' + d + '=' + env_dir)
-                conf.options.mpfr_libdir=env_dir
+                conf.options.mpfr_libdir = env_dir
 
     if not conf.options.mpfr_dir:
-        env_dir=os.getenv('MPFR_DIR')
+        env_dir = os.getenv('MPFR_DIR')
         if env_dir:
             conf.to_log('Setting mpfr_dir using environment variable: ' + d + '=' + env_dir)
-            conf.options.mpfr_dir=env_dir
-                
+            conf.options.mpfr_dir = env_dir
+
     # Find MPFR
     if conf.options.mpfr_dir:
         conf.to_log('Using mpfr_dir: ' + conf.options.mpfr_dir)
         if not conf.options.mpfr_incdir:
             conf.to_log('Setting mpfr_incdir using mpfr_dir: ' + conf.options.mpfr_dir)
-            conf.options.mpfr_incdir=conf.options.mpfr_dir + "/include"
+            conf.options.mpfr_incdir = conf.options.mpfr_dir + "/include"
         if not conf.options.mpfr_libdir:
             conf.to_log('Setting mpfr_libdir using mpfr_dir: ' + conf.options.mpfr_dir)
-            conf.options.mpfr_libdir=conf.options.mpfr_dir + "/lib"
+            conf.options.mpfr_libdir = conf.options.mpfr_dir + "/lib"
 
     if conf.options.mpfr_incdir:
         conf.to_log('Using mpfr_incdir: ' + conf.options.mpfr_incdir)
-        mpfr_incdir=conf.options.mpfr_incdir.split()
+        mpfr_incdir = conf.options.mpfr_incdir.split()
     else:
-        mpfr_incdir=[]
+        mpfr_incdir = []
     if conf.options.mpfr_libdir:
         conf.to_log('Using mpfr_libdir: ' + conf.options.mpfr_libdir)
-        mpfr_libdir=conf.options.mpfr_libdir.split()
+        mpfr_libdir = conf.options.mpfr_libdir.split()
     else:
-        mpfr_libdir=[]
+        mpfr_libdir = []
 
     if conf.options.mpfr_libs:
         conf.to_log('Using mpfr_libs: ' + conf.options.mpfr_libs)
-        mpfr_libs=conf.options.mpfr_libs.split()
+        mpfr_libs = conf.options.mpfr_libs.split()
     else:
-        mpfr_libs=['mpfr']
+        mpfr_libs = ['mpfr']
 
-    conf.check_cxx(msg="Checking for MPFR",
-                   header_name='mpfr.h',
-                   includes=mpfr_incdir,
-                   uselib_store='mpfr',
-                   libpath=mpfr_libdir,
-                   rpath=mpfr_libdir,
-                   lib=mpfr_libs,
-                   use=['cxx17', 'gmpxx'])
+    check_config(conf,
+                 fragment='''
+#include <mpfr.h>
+int main()
+{
+  mpfr_t x;
+  mpfr_init(x);
+}
+                 ''',
+                 includes=mpfr_incdir,
+                 uselib_store='mpfr',
+                 libpath=mpfr_libdir,
+                 lib=mpfr_libs,
+                 use=['cxx17', 'gmpxx'])
+
 
 def options(opt):
-    mpfr=opt.add_option_group('MPFR Options')
+    mpfr = opt.add_option_group('MPFR Options')
     mpfr.add_option('--mpfr-dir',
-                   help='Base directory where mpfr is installed')
+                    help='Base directory where mpfr is installed')
     mpfr.add_option('--mpfr-incdir',
-                   help='Directory where mpfr include files are installed')
+                    help='Directory where mpfr include files are installed')
     mpfr.add_option('--mpfr-libdir',
-                   help='Directory where mpfr library files are installed')
+                    help='Directory where mpfr library files are installed')
     mpfr.add_option('--mpfr-libs',
-                   help='Names of the mpfr libraries without prefix or suffix\n'
-                   '(e.g. "mpfr")')
+                    help='Names of the mpfr libraries without prefix or suffix\n'
+                         '(e.g. "mpfr")')

--- a/waf-tools/rapidjson.py
+++ b/waf-tools/rapidjson.py
@@ -1,30 +1,32 @@
 #! /usr/bin/env python
 # encoding: utf-8
 
-def configure(conf):
-    def get_param(varname,default):
-        return getattr(Options.options,varname,'')or default
+from check_config import check_config
 
-    import os
+
+def configure(conf):
     # Find Rapidjson
     if conf.options.rapidjson_dir:
         if not conf.options.rapidjson_incdir:
-            conf.options.rapidjson_incdir=conf.options.rapidjson_dir + "/include"
+            conf.options.rapidjson_incdir = conf.options.rapidjson_dir + "/include"
 
     if conf.options.rapidjson_incdir:
-        rapidjson_incdir=conf.options.rapidjson_incdir.split()
+        rapidjson_incdir = conf.options.rapidjson_incdir.split()
     else:
-        rapidjson_incdir=[]
+        rapidjson_incdir = []
 
-    conf.check_cxx(msg="Checking for rapidjson",
-                   fragment="#include <rapidjson/reader.h>\nint main() {rapidjson::Reader();}\n",
-                   includes=rapidjson_incdir,
-                   uselib_store='rapidjson',
-                   use=['cxx17'])
+    check_config(conf,
+                 fragment="#include <rapidjson/reader.h>\nint main() {rapidjson::Reader();}\n",
+                 includes=rapidjson_incdir,
+                 uselib_store='rapidjson',
+                 libpath=[],
+                 lib=[],
+                 use=['cxx17'])
+
 
 def options(opt):
-    rapidjson=opt.add_option_group('Rapidjson Options')
+    rapidjson = opt.add_option_group('Rapidjson Options')
     rapidjson.add_option('--rapidjson-dir',
-                   help='Base directory where rapidjson is installed')
+                         help='Base directory where rapidjson is installed')
     rapidjson.add_option('--rapidjson-incdir',
-                   help='Directory where rapidjson include files are installed')
+                         help='Directory where rapidjson include files are installed')


### PR DESCRIPTION
- Fix #242 
- Fix #72 

In `waf configure`, first, we check for dependencies in default and user-specified (e.g. `--mpfr-dir`) directories.
If compilation for a code fragment fails, we search for a package in `pkg-config`, e.g.
```
$ pkg-config --cflags --libs  mpfr
```

This is implemented in `waf-tools/check_config.py`.


Example output from `waf configure`:
```
Setting top to                           : /home/vasdommes/bootstrap/sdpb
Setting out to                           : /home/vasdommes/bootstrap/sdpb/build
Checking for 'g++' (C++ compiler)        : mpicxx
Checking for C++17 features              : yes
Checking for boost                       : yes
  Checking for boost_stacktrace_backtrace : yes
Checking for gmpxx                        : yes
Checking for mpfr                         : yes
Checking for elemental                    : yes
Checking for libxml2                      : no
  Searching for libxml-2.0 in pkg-config  : yes
  Checking libxml-2.0 compilation         : yes
Checking for rapidjson                    : yes
Checking for libarchive                   : yes
Checking for cblas                        : yes
Checking for flint                        : yes
'configure' finished successfully (6.310s)
```