### PR TITLE
Do not call create_directories() if parent path is empty

### DIFF
--- a/src/outer_limits/Outer_Parameters/Outer_Parameters.cxx
+++ b/src/outer_limits/Outer_Parameters/Outer_Parameters.cxx
@@ -135,7 +135,8 @@ Outer_Parameters::Outer_Parameters(int argc, char *argv[])
 
           if(El::mpi::Rank() == 0)
             {
-              fs::create_directories(output_path.parent_path());
+              if(output_path.has_parent_path())
+                fs::create_directories(output_path.parent_path());
               std::ofstream ofs(output_path);
               ASSERT(ofs.good(), "Cannot write to outDir: ", output_path);
             }

--- a/src/outer_limits/main.cxx
+++ b/src/outer_limits/main.cxx
@@ -120,7 +120,8 @@ int main(int argc, char **argv)
         {
           std::cout << "Saving solution to " << parameters.output_path << "\n";
         }
-      fs::create_directories(parameters.output_path.parent_path());
+      if(parameters.output_path.has_parent_path())
+        fs::create_directories(parameters.output_path.parent_path());
       std::ofstream output(parameters.output_path);
       set_stream_precision(output);
       output << "{\n  \"optimal\": \"" << optimal << "\",\n"

--- a/src/pmp2functions/write_functions.cxx
+++ b/src/pmp2functions/write_functions.cxx
@@ -22,7 +22,8 @@ void write_functions(const fs::path &output_path,
       normalization.at(0) = 1;
     }
 
-  fs::create_directories(output_path.parent_path());
+  if(output_path.has_parent_path())
+    fs::create_directories(output_path.parent_path());
   std::ofstream output_stream(output_path);
   set_stream_precision(output_stream);
   output_stream << "{\n  \"objective\":\n";

--- a/src/sdpb_util/Timers/Timers.cxx
+++ b/src/sdpb_util/Timers/Timers.cxx
@@ -49,7 +49,7 @@ Timer &Timers::add_and_start(const std::string &name)
 }
 void Timers::write_profile(const std::filesystem::path &path) const
 {
-  if(!path.parent_path().empty())
+  if(path.has_parent_path())
     std::filesystem::create_directories(path.parent_path());
   std::ofstream f(path);
 

--- a/src/sdpb_util/write_distmatrix.hxx
+++ b/src/sdpb_util/write_distmatrix.hxx
@@ -8,7 +8,8 @@ inline void write_distmatrix(const El::DistMatrix<El::BigFloat> &matrix,
   std::ofstream stream;
   if(matrix.DistRank() == matrix.Root())
     {
-      std::filesystem::create_directories(path.parent_path());
+      if(path.has_parent_path())
+        std::filesystem::create_directories(path.parent_path());
       stream.open(path);
     }
   El::Print(matrix,

--- a/src/spectrum/write_spectrum/write_file.cxx
+++ b/src/spectrum/write_spectrum/write_file.cxx
@@ -11,7 +11,8 @@ void write_file(const fs::path &output_path,
 {
   if(El::mpi::Rank() == 0)
     {
-      fs::create_directories(output_path.parent_path());
+      if(output_path.has_parent_path())
+        fs::create_directories(output_path.parent_path());
       std::ofstream outfile(output_path);
       ASSERT(outfile.good(),
              "Problem when opening output file: ", output_path);

--- a/test/src/integration_tests/cases/sdpb.test.cxx
+++ b/test/src/integration_tests/cases/sdpb.test.cxx
@@ -38,7 +38,8 @@ TEST_CASE("sdpb")
 
   // create file with readonly premissions
   auto create_readonly = [](const fs::path &path) {
-    create_directories(path.parent_path());
+    if(path.has_parent_path())
+      create_directories(path.parent_path());
     std::ofstream os(path);
     os << "";
     fs::permissions(path, fs::perms::others_read);

--- a/test/src/integration_tests/util/Test_Case_Runner.cxx
+++ b/test/src/integration_tests/util/Test_Case_Runner.cxx
@@ -71,7 +71,8 @@ namespace Test_Util
     fs::remove_all(output_dir);
     fs::remove_all(Test_Config::test_log_dir / name);
 
-    fs::create_directories(stdout_path.parent_path());
+    if(stdout_path.has_parent_path())
+      fs::create_directories(stdout_path.parent_path());
     ASSERT(fs::is_directory(stdout_path.parent_path()),
            stdout_path.parent_path(),
            " is not a directory! Check file name and permissions.");


### PR DESCRIPTION
Otherwise, it throws `Error: filesystem error: cannot create directories: Invalid argument []` e.g. if you run
`spectrum --output test.json`