### PR TITLE
Minor fixes: less verbose warnings, compilation error for old libarchive

### DIFF
--- a/src/approx_objective/Approx_Parameters.hxx
+++ b/src/approx_objective/Approx_Parameters.hxx
@@ -8,7 +8,7 @@
 
 struct Approx_Parameters
 {
-  size_t proc_granularity;
+  size_t proc_granularity = 1;
   size_t precision;
   size_t max_shared_memory_bytes;
 

--- a/src/approx_objective/Approx_Parameters/Approx_Parameters.cxx
+++ b/src/approx_objective/Approx_Parameters/Approx_Parameters.cxx
@@ -81,7 +81,7 @@ Approx_Parameters::Approx_Parameters(int argc, char *argv[])
     "[OBSOLETE] The number of MPI processes running on a node. "
     "Determined automatically from MPI environment.");
   obsolete_options.add_options()(
-    "procGranularity", po::value<size_t>(&proc_granularity)->default_value(1),
+    "procGranularity", po::value<size_t>(&proc_granularity),
     "[OBSOLETE] procGranularity must evenly divide number of processes per "
     "node.\n\n"
     "The minimum number of cores in a group, used during load balancing.  "

--- a/src/sdpb/SDPB_Parameters.hxx
+++ b/src/sdpb/SDPB_Parameters.hxx
@@ -12,7 +12,7 @@
 struct SDPB_Parameters
 {
   bool no_final_checkpoint;
-  size_t proc_granularity;
+  size_t proc_granularity = 1;
   bool require_initial_checkpoint = false;
   Write_Solution write_solution;
 

--- a/src/sdpb/SDPB_Parameters/SDPB_Parameters.cxx
+++ b/src/sdpb/SDPB_Parameters/SDPB_Parameters.cxx
@@ -106,7 +106,16 @@ SDPB_Parameters::SDPB_Parameters(int argc, char *argv[])
                          EL_VERSION_MINOR);
               El::Output("  FLINT ", FLINT_VERSION);
               El::Output("  GMP ", gmp_version);
+#if defined ARCHIVE_VERSION_STRING
+              El::Output("  ", ARCHIVE_VERSION_STRING);
+#elif defined ARCHIVE_LIBRARY_VERSION
+              // this macro is defined in older versions, e.g. libarchive 2.0
+              El::Output("  ", ARCHIVE_LIBRARY_VERSION);
+#elif defined ARCHIVE_VERSION_ONLY_STRING
               El::Output("  libarchive ", ARCHIVE_VERSION_ONLY_STRING);
+#else
+              El::Output("  libarchive");
+#endif
               El::Output("  libxml ", LIBXML_DOTTED_VERSION);
               El::Output("  MPFR ", MPFR_VERSION_STRING);
               El::Output("  RapidJSON ", RAPIDJSON_VERSION_STRING);

--- a/src/sdpb/SDPB_Parameters/SDPB_Parameters.cxx
+++ b/src/sdpb/SDPB_Parameters/SDPB_Parameters.cxx
@@ -69,7 +69,7 @@ SDPB_Parameters::SDPB_Parameters(int argc, char *argv[])
     "[OBSOLETE] The number of MPI processes running on a node. "
     "Determined automatically from MPI environment.");
   obsolete_options.add_options()(
-    "procGranularity", po::value<size_t>(&proc_granularity)->default_value(1),
+    "procGranularity", po::value<size_t>(&proc_granularity),
     "[OBSOLETE] procGranularity must evenly divide number of processes per "
     "node.\n\n"
     "The minimum number of cores in a group, used during load balancing.  "

--- a/src/sdpb_util/memory_estimates.cxx
+++ b/src/sdpb_util/memory_estimates.cxx
@@ -70,7 +70,11 @@ size_t get_max_shared_memory_bytes(
                           "\n\tIn case of OOM, consider increasing number of "
                           "nodes and/or decreasing --maxSharedMemory limit.");
         }
-      PRINT_WARNING(ss.str());
+      if(verbosity >= Verbosity::regular)
+        {
+          if(env.node_index() == 0 || verbosity >= Verbosity::debug)
+            PRINT_WARNING(ss.str());
+        }
     }
   // All ranks on a node should have the same limit
   El::mpi::Broadcast(max_shared_memory_bytes, 0, env.comm_shared_mem);


### PR DESCRIPTION
- Fix compilation error `‘ARCHIVE_VERSION_ONLY_STRING’ was not declared` for old `libarchive` versions
- Fix #249 
- Less verbose `--maxSharedMemory` warning: do not print for `--verbosity=none`, print only for the first node for `--verbosity=regular`