### PR TITLE
Fix swap for Block_Info

### DIFF
--- a/src/pmp/Damped_Rational.hxx
+++ b/src/pmp/Damped_Rational.hxx
@@ -38,9 +38,9 @@ struct Damped_Rational
   }
 };
 
-inline void swap(Damped_Rational &a, Damped_Rational &b)
+inline void swap(Damped_Rational &a, Damped_Rational &b) noexcept
 {
-  using namespace std;
+  using std::swap;
   swap(a.constant, b.constant);
   swap(a.base, b.base);
   swap(a.poles, b.poles);

--- a/src/pmp/Damped_Rational.hxx
+++ b/src/pmp/Damped_Rational.hxx
@@ -38,6 +38,14 @@ struct Damped_Rational
   }
 };
 
+inline void swap(Damped_Rational &a, Damped_Rational &b)
+{
+  using namespace std;
+  swap(a.constant, b.constant);
+  swap(a.base, b.base);
+  swap(a.poles, b.poles);
+}
+
 inline std::ostream &
 operator<<(std::ostream &os, const Damped_Rational &damped)
 {

--- a/src/pmp/Polynomial.hxx
+++ b/src/pmp/Polynomial.hxx
@@ -100,7 +100,7 @@ inline void swap(Polynomial_Vector &polynomials,
   for(auto &elements : elements_vector)
     {
       polynomials.emplace_back();
-      std::swap(polynomials.back().coefficients, elements);
+      swap(polynomials.back().coefficients, elements);
     }
 }
 

--- a/src/sdp_solve/Block_Info.hxx
+++ b/src/sdp_solve/Block_Info.hxx
@@ -27,15 +27,6 @@ public:
   // Rename block_info.block_indices to local_block_indices to make it clearer
 
   Block_Info() = delete;
-
-  // Allow move
-  Block_Info(Block_Info &&other) noexcept = default;
-  Block_Info &operator=(Block_Info &&other) noexcept = default;
-  // Prohibit copy
-  Block_Info(const Block_Info &) = delete;
-  Block_Info &operator=(const Block_Info &) = delete;
-  ~Block_Info() = default;
-
   Block_Info(const Environment &env, const std::filesystem::path &sdp_path,
              const std::filesystem::path &checkpoint_in,
              const size_t &proc_granularity, const Verbosity &verbosity);
@@ -127,3 +118,16 @@ public:
     return num_points.at(index);
   }
 };
+
+namespace std
+{
+  inline void swap(Block_Info &a, Block_Info &b)
+  {
+    swap(a.block_timings_filename, b.block_timings_filename);
+    swap(a.dimensions, b.dimensions);
+    swap(a.num_points, b.num_points);
+    swap(a.block_indices, b.block_indices);
+    swap(a.mpi_group, b.mpi_group);
+    swap(a.mpi_comm, b.mpi_comm);
+  }
+}

--- a/src/sdp_solve/Block_Info.hxx
+++ b/src/sdp_solve/Block_Info.hxx
@@ -119,15 +119,13 @@ public:
   }
 };
 
-namespace std
+inline void swap(Block_Info &a, Block_Info &b) noexcept
 {
-  inline void swap(Block_Info &a, Block_Info &b)
-  {
-    swap(a.block_timings_filename, b.block_timings_filename);
-    swap(a.dimensions, b.dimensions);
-    swap(a.num_points, b.num_points);
-    swap(a.block_indices, b.block_indices);
-    swap(a.mpi_group, b.mpi_group);
-    swap(a.mpi_comm, b.mpi_comm);
-  }
+  using std::swap;
+  swap(a.block_timings_filename, b.block_timings_filename);
+  swap(a.dimensions, b.dimensions);
+  swap(a.num_points, b.num_points);
+  swap(a.block_indices, b.block_indices);
+  swap(a.mpi_group, b.mpi_group);
+  swap(a.mpi_comm, b.mpi_comm);
 }

--- a/src/sdpb/main.cxx
+++ b/src/sdpb/main.cxx
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
           Block_Info new_info(env, parameters.sdp_path, block_timings_ms,
                               parameters.proc_granularity,
                               parameters.verbosity);
-          std::swap(block_info, new_info);
+          swap(block_info, new_info);
 
           auto elapsed_seconds
             = std::chrono::duration_cast<std::chrono::seconds>(

--- a/src/sdpb_util/Vector_State.hxx
+++ b/src/sdpb_util/Vector_State.hxx
@@ -73,8 +73,9 @@ public:
           {
             if(!element_state.inside)
               {
+                using std::swap;
                 value.emplace_back();
-                std::swap(value.back(), element_state.value);
+                swap(value.back(), element_state.value);
               }
           }
         else
@@ -102,8 +103,9 @@ public:
     element_state.json_string(s);
     if(!element_state.inside)
       {
+        using std::swap;
         value.emplace_back();
-        std::swap(value.back(), element_state.value);
+        swap(value.back(), element_state.value);
       }
   }
 
@@ -127,8 +129,9 @@ public:
         element_state.json_end_array();
         if(!element_state.inside)
           {
+            using std::swap;
             value.emplace_back();
-            std::swap(value.back(), element_state.value);
+            swap(value.back(), element_state.value);
           }
       }
     else
@@ -144,8 +147,9 @@ public:
     element_state.json_end_object();
     if(!element_state.inside)
       {
+        using std::swap;
         value.emplace_back();
-        std::swap(value.back(), element_state.value);
+        swap(value.back(), element_state.value);
       }
   }
 };

--- a/src/sdpb_util/block_mapping/MPI_Comm_Wrapper.hxx
+++ b/src/sdpb_util/block_mapping/MPI_Comm_Wrapper.hxx
@@ -17,10 +17,8 @@ struct MPI_Comm_Wrapper
   }
 };
 
-namespace std
+inline void swap(MPI_Comm_Wrapper &a, MPI_Comm_Wrapper &b) noexcept
 {
-  inline void swap(MPI_Comm_Wrapper &a, MPI_Comm_Wrapper &b) noexcept
-  {
-    swap(a.value, b.value);
-  }
+  using std::swap;
+  swap(a.value, b.value);
 }

--- a/src/sdpb_util/block_mapping/MPI_Comm_Wrapper.hxx
+++ b/src/sdpb_util/block_mapping/MPI_Comm_Wrapper.hxx
@@ -6,12 +6,8 @@ struct MPI_Comm_Wrapper
 {
   El::mpi::Comm value;
   MPI_Comm_Wrapper() = default;
-  // Allow move
-  MPI_Comm_Wrapper(MPI_Comm_Wrapper &&other) noexcept = default;
-  MPI_Comm_Wrapper &operator=(MPI_Comm_Wrapper &&other) noexcept = default;
-  // Prohibit copy
   MPI_Comm_Wrapper(const MPI_Comm_Wrapper &) = delete;
-  MPI_Comm_Wrapper &operator=(const MPI_Comm_Wrapper &) = delete;
+  void operator=(const MPI_Comm_Wrapper &) = delete;
   ~MPI_Comm_Wrapper()
   {
     if(value != El::mpi::COMM_WORLD)
@@ -20,3 +16,11 @@ struct MPI_Comm_Wrapper
       }
   }
 };
+
+namespace std
+{
+  inline void swap(MPI_Comm_Wrapper &a, MPI_Comm_Wrapper &b) noexcept
+  {
+    swap(a.value, b.value);
+  }
+}

--- a/src/sdpb_util/block_mapping/MPI_Group_Wrapper.hxx
+++ b/src/sdpb_util/block_mapping/MPI_Group_Wrapper.hxx
@@ -17,10 +17,8 @@ struct MPI_Group_Wrapper
   }
 };
 
-namespace std
+inline void swap(MPI_Group_Wrapper &a, MPI_Group_Wrapper &b) noexcept
 {
-  inline void swap(MPI_Group_Wrapper &a, MPI_Group_Wrapper &b) noexcept
-  {
-    swap(a.value, b.value);
-  }
+  using std::swap;
+  swap(a.value, b.value);
 }

--- a/src/sdpb_util/block_mapping/MPI_Group_Wrapper.hxx
+++ b/src/sdpb_util/block_mapping/MPI_Group_Wrapper.hxx
@@ -5,15 +5,9 @@
 struct MPI_Group_Wrapper
 {
   El::mpi::Group value;
-
   MPI_Group_Wrapper() = default;
-  // Allow move
-  MPI_Group_Wrapper(MPI_Group_Wrapper &&other) noexcept = default;
-  MPI_Group_Wrapper &operator=(MPI_Group_Wrapper &&other) noexcept = default;
-  // Prohibit copy
   MPI_Group_Wrapper(const MPI_Group_Wrapper &) = delete;
-  MPI_Group_Wrapper &operator=(const MPI_Group_Wrapper &) = delete;
-
+  void operator=(const MPI_Group_Wrapper &) = delete;
   ~MPI_Group_Wrapper()
   {
     if(value != El::mpi::GROUP_NULL)
@@ -22,3 +16,11 @@ struct MPI_Group_Wrapper
       }
   }
 };
+
+namespace std
+{
+  inline void swap(MPI_Group_Wrapper &a, MPI_Group_Wrapper &b) noexcept
+  {
+    swap(a.value, b.value);
+  }
+}


### PR DESCRIPTION
Revert commit https://github.com/davidsd/sdpb/commit/ec6c5b597b7bb01ef476868ddf0828c24c4b663f that introduced default `std::swap()` for `Block_Info`.
Sometimes default std::swap was leading to crashes with `free(): corrupted unsorted chunks`, probably due to incorrect pointer handling when moving `MPI_Comm_Wrapper` and `MPI_Group_Wrapper`.

Also cleaned up swap code according to C++ Core Guidelines: [using std::swap;](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c165-use-using-for-customization-points), added [noexcept](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#discussion-destructors-deallocation-and-swap-must-never-fail)