### PR TITLE
Fix #271 write_distmatrix() works incorrectly for DistMatrix<T,STAR,STAR>

### DIFF
--- a/src/sdpb_util/write_distmatrix.hxx
+++ b/src/sdpb_util/write_distmatrix.hxx
@@ -2,24 +2,40 @@
 
 #include <El.hpp>
 
-inline void
-write_distmatrix(const El::AbstractDistMatrix<El::BigFloat> &matrix,
-                 const std::filesystem::path &path)
+template <class T>
+void write_matrix(const El::Matrix<T> &matrix,
+                  const std::filesystem::path &path)
 {
-  std::ofstream stream;
-  if(matrix.DistRank() == matrix.Root())
-    {
-      if(path.has_parent_path())
-        std::filesystem::create_directories(path.parent_path());
-      stream.open(path);
-    }
+  if(path.has_parent_path())
+    std::filesystem::create_directories(path.parent_path());
+  std::ofstream stream(path);
   El::Print(matrix,
             std::to_string(matrix.Height()) + " "
               + std::to_string(matrix.Width()),
             "\n", stream);
-  if(matrix.DistRank() == matrix.Root())
+  stream << "\n";
+  ASSERT(stream.good(), "Error when writing to: ", path);
+}
+
+// Code adapted from El::Print(const El::AbstractDistMatrix<T> &, ...)
+// to work with with std::filesystem::path instead of ostream&
+template <class T>
+void write_distmatrix(const El::AbstractDistMatrix<T> &A,
+                      const std::filesystem::path &path)
+{
+  if(A.ColStride() == 1 && A.RowStride() == 1)
     {
-      stream << "\n";
-      ASSERT(stream.good(), "Error when writing to: ", path);
+      if(A.CrossRank() == A.Root() && A.RedundantRank() == 0)
+        {
+          write_matrix(A.LockedMatrix(), path);
+        }
+    }
+  else
+    {
+      El::DistMatrix<T, El::CIRC, El::CIRC> A_CIRC_CIRC(A);
+      if(A_CIRC_CIRC.CrossRank() == A_CIRC_CIRC.Root())
+        {
+          write_matrix(A_CIRC_CIRC.LockedMatrix(), path);
+        }
     }
 }

--- a/test/src/integration_tests/util/diff_sdpb_out.cxx
+++ b/test/src/integration_tests/util/diff_sdpb_out.cxx
@@ -31,6 +31,7 @@ namespace
       height = width = 0;
       is >> height;
       is >> width;
+      REQUIRE(is.good());
       REQUIRE(height > 0);
       REQUIRE(width > 0);
       elements.reserve(height * width);


### PR DESCRIPTION
Fixes #271
The updated code copies logic from `El::Print()`