### PR TITLE
Minor fixes: simplify `copy_matrix`, check `time` command, print MPSolve version, improve warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@
 # based on the same alpine:3.18 build as below
 
 # Built from https://github.com/vasdommes/flint/tree/docker-main
-FROM vasdommes/flint:main as flint
+FROM vasdommes/flint:main AS flint
 
 FROM bootstrapcollaboration/elemental:master AS build
 
@@ -82,7 +82,7 @@ RUN (./waf configure --elemental-dir=/usr/local --flint-dir=/usr/local --prefix=
 # Unfortunately, boost1.82-stacktrace_addr2line does not exist as a standalone package in Alpine Linux repo.
 # Thus we have to load the whole boost-dev (~180MB extra)
 # TODO: for some reason, function names and source locations are not printed in stacktrace.
-FROM alpine:3.19 as install
+FROM alpine:3.19 AS install
 RUN apk add \
     binutils \
     boost-dev \
@@ -111,7 +111,7 @@ COPY --from=build /usr/local/lib /usr/local/lib
 #
 # docker build . -t sdpb-test --target test
 # docker run sdpb-test ./test/run_all_tests.sh mpirun --oversubscribe
-FROM install as test
+FROM install AS test
 # Create testuser to run Docker non-root (and avoid 'mpirun --allow-run-as-root' warning)
 RUN addgroup --gid 10000 testgroup && \
     adduser --disabled-password --uid 10000 --ingroup testgroup --shell /bin/sh testuser

--- a/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/BigInt_Shared_Memory_Syrk_Context.cxx
+++ b/src/sdp_solve/SDP_Solver/run/bigint_syrk/BigInt_Shared_Memory_Syrk_Context/BigInt_Shared_Memory_Syrk_Context.cxx
@@ -216,7 +216,7 @@ BigInt_Shared_Memory_Syrk_Context::BigInt_Shared_Memory_Syrk_Context(
   ASSERT(input_window_split_factor > 0);
 
   // Print warnings for large split factors.
-  if(shared_memory_comm.Rank() == 0)
+  if(shared_memory_comm.Rank() == 0 && verbosity >= Verbosity::regular)
     {
       const bool print_output_warning = output_window_split_factor > 1;
       const bool print_input_warning = input_window_split_factor > 10;

--- a/src/sdpb/SDPB_Parameters.cxx
+++ b/src/sdpb/SDPB_Parameters.cxx
@@ -7,6 +7,7 @@
 #include <mpfr.h>
 #include <libxml/xmlversion.h>
 #include <rapidjson/rapidjson.h>
+#include <mps/mps.h>
 
 namespace fs = std::filesystem;
 
@@ -117,6 +118,12 @@ SDPB_Parameters::SDPB_Parameters(int argc, char *argv[])
 #endif
               El::Output("  libxml ", LIBXML_DOTTED_VERSION);
               El::Output("  MPFR ", MPFR_VERSION_STRING);
+              // TODO: linker fails with "undefined reference ot mps_get_version()"
+              // even though we link to MPSolve library.
+              // Thus, we have to use MPS_MAJOR_VERSION etc.
+              // El::Output("  MPSolve ", mps_get_version());
+              El::Output("  MPSolve ", MPS_MAJOR_VERSION, ".",
+                         MPS_MINOR_VERSION, ".", MPS_PATCH_VERSION);
               El::Output("  RapidJSON ", RAPIDJSON_VERSION_STRING);
               // We should also print CBLAS version,
               // but the standard interface cblas.h does not have version macro.

--- a/src/sdpb_util/copy_matrix.cxx
+++ b/src/sdpb_util/copy_matrix.cxx
@@ -2,17 +2,19 @@
 #include "Shared_Window_Array.hxx"
 #include "assert.hxx"
 
+// TODO: maybe it's better to store source as El::DistMatrix<El::BigFloat,STAR,STAR>?
+// Check and update usages.
 void copy_matrix(const El::Matrix<El::BigFloat> &source,
                  El::DistMatrix<El::BigFloat> &destination)
 {
   destination.Resize(source.Height(), source.Width());
-  for(int64_t row(0); row < destination.LocalHeight(); ++row)
+  for(int iLoc = 0; iLoc < destination.LocalHeight(); ++iLoc)
     {
-      int64_t global_row(destination.GlobalRow(row));
-      for(int64_t column(0); column < destination.LocalWidth(); ++column)
+      const int i = destination.GlobalRow(iLoc);
+      for(int jLoc = 0; jLoc < destination.LocalWidth(); ++jLoc)
         {
-          int64_t global_column(destination.GlobalCol(column));
-          destination.SetLocal(row, column, source(global_row, global_column));
+          const int j = destination.GlobalCol(jLoc);
+          destination.SetLocal(iLoc, jLoc, source(i, j));
         }
     }
 }
@@ -20,124 +22,15 @@ void copy_matrix(const El::Matrix<El::BigFloat> &source,
 void copy_matrix(const El::DistMatrix<El::BigFloat, El::STAR, El::STAR> &source,
                  El::Matrix<El::BigFloat> &destination)
 {
-  destination.Resize(source.LocalHeight(), source.LocalWidth());
-  for(int64_t row(0); row < source.LocalHeight(); ++row)
-    {
-      for(int64_t column(0); column < source.LocalWidth(); ++column)
-        {
-          destination(row, column) = source.GetLocal(row, column);
-        }
-    }
+  El::Copy(source.LockedMatrix(), destination);
 }
 
 void copy_matrix(const El::DistMatrix<El::BigFloat, El::STAR, El::STAR> &source,
                  El::DistMatrix<El::BigFloat> &destination)
 {
-  destination.Resize(source.LocalHeight(), source.LocalWidth());
-  for(int64_t row(0); row < destination.LocalHeight(); ++row)
-    {
-      const int64_t global_row(destination.GlobalRow(row));
-      for(int64_t column(0); column < destination.LocalWidth(); ++column)
-        {
-          const int64_t global_column(destination.GlobalCol(column));
-          destination.SetLocal(row, column,
-                               source.GetLocal(global_row, global_column));
-        }
-    }
-}
-
-// source: Matrix initialized at comm.Rank() = 0
-// destination: DistMatrix of the same size, elements will be copied from comm root.
-// comm should be equal to output.DistComm()
-// (this argument is added for safety check)
-//
-// In our real-world tests, this version is ~3x slower than copy_matrix_from_root_impl_shared_window()
-void copy_matrix_from_root_impl_send_recv(
-  const El::Matrix<El::BigFloat> &source,
-  El::DistMatrix<El::BigFloat> &destination, const El::mpi::Comm &comm)
-{
-  const El::Int root = 0;
-  const El::Int rank = comm.Rank();
-
-  for(El::Int global_row = 0; global_row < destination.Height(); ++global_row)
-    for(El::Int global_col = 0; global_col < destination.Width(); ++global_col)
-      {
-        const auto from = root;
-        const auto to = destination.Owner(global_row, global_col);
-        // special case: copy from root to root, no MPI messaging needed
-        if(to == from)
-          {
-            if(rank == to)
-              {
-                destination.Set(global_row, global_col,
-                                source.Get(global_row, global_col));
-              }
-            continue;
-          }
-        // send from root
-        if(rank == from)
-          {
-            El::mpi::Send(source.Get(global_row, global_col), to, comm);
-          }
-        // recieve by element owner
-        if(rank == to)
-          {
-            destination.Set(global_row, global_col,
-                            El::mpi::Recv<El::BigFloat>(from, comm));
-          }
-      }
-}
-
-// source: Matrix initialized at comm.Rank() = 0
-// destination: DistMatrix of the same size, elements will be copied from comm root.
-// comm should be equal to output.DistComm()
-// (this argument is added for safety check)
-void copy_matrix_from_root_impl_shared_window(
-  const El::Matrix<El::BigFloat> &source,
-  El::DistMatrix<El::BigFloat> &destination, const El::mpi::Comm &comm)
-{
-  const El::Int root = 0;
-  const El::Int rank = comm.Rank();
-
-  const auto bigfloat_size_bytes
-    = El::BigFloat(1).SerializedSize() / sizeof(El::byte);
-
-  Shared_Window_Array<El::byte> window(
-    comm, destination.Height() * destination.Width() * bigfloat_size_bytes);
-
-  const int ldim = destination.Height();
-  auto get_buffer = [&](int i, int j) -> El::byte * {
-    return window.data + (i + j * ldim) * bigfloat_size_bytes;
-  };
-
-  // Serialize input matrix to shared memory window
-  if(rank == root)
-    {
-      for(int i = 0; i < source.Height(); ++i)
-        for(int j = 0; j < source.Width(); ++j)
-          {
-            source.Get(i, j).Serialize(get_buffer(i, j));
-          }
-    }
-  window.Fence();
-
-  // Deserialize to output
-  for(int iLoc = 0; iLoc < destination.LocalHeight(); ++iLoc)
-    for(int jLoc = 0; jLoc < destination.LocalWidth(); ++jLoc)
-      {
-        int i = destination.GlobalRow(iLoc);
-        int j = destination.GlobalCol(jLoc);
-        if(rank == root)
-          {
-            destination.SetLocal(iLoc, jLoc, source.Get(i, j));
-          }
-        else
-          {
-            El::BigFloat value;
-            value.Deserialize(get_buffer(i, j));
-            destination.SetLocal(iLoc, jLoc, value);
-          }
-      }
+  // NB: Calling El::Copy(source, destination) may lead to "Grids did not match" error,
+  // if e.g. source is global and destination is local to some MPI group.
+  copy_matrix(source.LockedMatrix(), destination);
 }
 
 // source: Matrix initialized at comm.Rank() = 0
@@ -163,20 +56,14 @@ void copy_matrix_from_root(const El::Matrix<El::BigFloat> &source,
 
   if(comm.Size() == 1)
     {
-      copy_matrix(source, destination);
+      El::Copy(source, destination.Matrix());
       return;
     }
-
-  // In our real-world tests, copy_matrix_from_root_impl_shared_window() was ~3x faster than copy_matrix_from_root_impl_send_recv()
-  // Thus we use it when possible, i.e. when all ranks are on the same node
-
-  El::mpi::Comm shared_memory_comm;
-  MPI_Comm_split_type(comm.comm, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
-                      &shared_memory_comm.comm);
-
-  if(El::mpi::Congruent(comm, shared_memory_comm))
-    copy_matrix_from_root_impl_shared_window(source, destination, comm);
-  else
-    copy_matrix_from_root_impl_send_recv(source, destination, comm);
-  El::mpi::Free(shared_memory_comm);
+  if(comm.Rank() == 0)
+    {
+      for(int i = 0; i < source.Height(); ++i)
+        for(int j = 0; j < source.Width(); ++j)
+          destination.QueueUpdate(i, j, source.Get(i, j));
+    }
+  destination.ProcessQueues();
 }

--- a/src/sdpb_util/memory_estimates.cxx
+++ b/src/sdpb_util/memory_estimates.cxx
@@ -70,10 +70,17 @@ size_t get_max_shared_memory_bytes(
                           "\n\tIn case of OOM, consider increasing number of "
                           "nodes and/or decreasing --maxSharedMemory limit.");
         }
+      // If we don't have enough memory,
+      // we want to print OOM warning for any verbosity
+      if(nonshared_memory_required_per_node_bytes > mem_total_bytes
+         || verbosity >= Verbosity::debug)
+        {
+          PRINT_WARNING(ss.str());
+        }
       if(verbosity >= Verbosity::regular)
         {
-          if(env.node_index() == 0 || verbosity >= Verbosity::debug)
-            PRINT_WARNING(ss.str());
+          El::Output("node=", env.node_index(), ": Set --maxSharedMemory=",
+                     pretty_print_bytes(max_shared_memory_bytes, true));
         }
     }
   // All ranks on a node should have the same limit

--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -23,11 +23,23 @@ else
   MPI_RUN_COMMAND="mpirun --oversubscribe"
 fi
 
-# Find existing time command, see https://stackoverflow.com/a/677212/3270684
-if command -v /usr/bin/time >/dev/null 2>&1; then
-    TIME_CMD="/usr/bin/time"
-elif command -v time >/dev/null 2>&1; then
+echo "Checking MPI_RUN_COMMAND=$MPI_RUN_COMMAND"
+$MPI_RUN_COMMAND -n 6 echo Hello >/dev/null
+ret=$?
+if [ $ret -ne 0 ]
+then
+  echo "Failed: $ret"
+  exit $ret
+fi
+
+# Find valid time command
+# /usr/bin/time
+if /usr/bin/time -- $MPI_RUN_COMMAND -n 6 echo Hello >/dev/null 2>&1; then
+    TIME_CMD="/usr/bin/time --"
+# Built-in time function (e.g. bash)
+elif time $MPI_RUN_COMMAND -n 6 echo Hello >/dev/null 2>&1; then
     TIME_CMD="time"
+# fallback: no timing, just run tests.
 else
     TIME_CMD=""
 fi

--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -23,16 +23,25 @@ else
   MPI_RUN_COMMAND="mpirun --oversubscribe"
 fi
 
+# Find existing time command, see https://stackoverflow.com/a/677212/3270684
+if command -v /usr/bin/time >/dev/null 2>&1; then
+    TIME_CMD="/usr/bin/time"
+elif command -v time >/dev/null 2>&1; then
+    TIME_CMD="time"
+else
+    TIME_CMD=""
+fi
+
 # Run unit_tests and integration_tests with timing info and custom mpirun command
 # For more command-line options, see
 # https://github.com/catchorg/Catch2/blob/devel/docs/command-line.md
 
 # NB: for calculate_matrix_square_test to pass, number of processes must be a multiple of 6
-echo time $MPI_RUN_COMMAND -n 6 ./build/unit_tests --durations yes
-time $MPI_RUN_COMMAND -n 6 ./build/unit_tests --durations yes || { exit $?; }
+echo $TIME_CMD "$MPI_RUN_COMMAND" -n 6 ./build/unit_tests --durations yes
+$TIME_CMD "$MPI_RUN_COMMAND" -n 6 ./build/unit_tests --durations yes || { exit $?; }
 
 # integration_tests
-echo time ./build/integration_tests --durations yes --mpirun="$MPI_RUN_COMMAND"
-time ./build/integration_tests --durations yes --mpirun="$MPI_RUN_COMMAND" || { exit $?; }
+echo $TIME_CMD ./build/integration_tests --durations yes --mpirun="$MPI_RUN_COMMAND"
+$TIME_CMD ./build/integration_tests --durations yes --mpirun="$MPI_RUN_COMMAND" || { exit $?; }
 
 echo "$0: ALL TESTS PASSED"

--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -37,8 +37,8 @@ fi
 # https://github.com/catchorg/Catch2/blob/devel/docs/command-line.md
 
 # NB: for calculate_matrix_square_test to pass, number of processes must be a multiple of 6
-echo $TIME_CMD "$MPI_RUN_COMMAND" -n 6 ./build/unit_tests --durations yes
-$TIME_CMD "$MPI_RUN_COMMAND" -n 6 ./build/unit_tests --durations yes || { exit $?; }
+echo $TIME_CMD $MPI_RUN_COMMAND -n 6 ./build/unit_tests --durations yes
+$TIME_CMD $MPI_RUN_COMMAND -n 6 ./build/unit_tests --durations yes || { exit $?; }
 
 # integration_tests
 echo $TIME_CMD ./build/integration_tests --durations yes --mpirun="$MPI_RUN_COMMAND"

--- a/test/src/unit_tests/cases/calculate_matrix_square.test.cxx
+++ b/test/src/unit_tests/cases/calculate_matrix_square.test.cxx
@@ -348,7 +348,7 @@ TEST_CASE("calculate_Block_Matrix_square")
                                      num_groups_per_node, node_comm);
 
                   {
-                    const Verbosity verbosity = Verbosity::regular;
+                    constexpr auto verbosity = Verbosity::none;
                     BigInt_Shared_Memory_Syrk_Context context(
                       node_comm, group_index_in_node,
                       group_comm_sizes_per_node, bits, max_shared_memory_bytes,

--- a/test/src/unit_tests/cases/create_blas_job_schedule.test.cxx
+++ b/test/src/unit_tests/cases/create_blas_job_schedule.test.cxx
@@ -25,7 +25,7 @@ TEST_CASE("create_blas_jobs_schedule")
     constexpr auto uplo = El::UPPER;
     auto schedule
       = create_blas_job_schedule(Blas_Job::syrk, uplo, num_ranks, num_primes,
-                                 Q_height, Q_width, Verbosity::regular);
+                                 Q_height, Q_width, Verbosity::none);
     {
       INFO("Check that schedule has correct number of ranks:");
       DIFF(schedule.jobs_by_rank.size(), num_ranks);

--- a/wscript
+++ b/wscript
@@ -129,7 +129,7 @@ def build(bld):
                 cxxflags=default_flags,
                 defines=default_defines,
                 includes=default_includes,
-                use=use_packages + ['sdp_solve']
+                use=use_packages + ['sdp_solve', 'mpsolve']
                 )
 
     pmp2sdp_sources = ['src/pmp2sdp/Dual_Constraint_Group/Dual_Constraint_Group.cxx',


### PR DESCRIPTION
- Improve `--maxSharedMemory` logging: always print warning if not enough memory, print node index
- `copy_matrix()` and `copy_matrix_from_root()`: simplify, use Elemental functions when possible.
- `sdpb --version`: print also MPSolve version
- `test/run_all_tests.sh`: check `mpirun` validity, choose between `/usr/bin/time`, `time` and no timing at all.
- Disable warnings about huge split factors in `BigInt_Shared_Memory_Syrk_Context` for `--verbosity=none`, disable them in unit tests.
- Dockerfile: use uppercase in all `FROM ... AS ...` commands.