### PR TITLE
integration tests: fix out.txt comparison

### DIFF
--- a/test/src/integration_tests/cases/end-to-end.test.cxx
+++ b/test/src/integration_tests/cases/end-to-end.test.cxx
@@ -23,6 +23,8 @@ namespace
     std::string name;
     int num_procs = 6;
     int precision = 768;
+    // Compare up to dualityGapThreshold = 1e-30 ~ 2^{-99.7}
+    int diff_precision = 99;
     Named_Args_Map pmp2sdp_args;
     std::vector<std::string> default_sdpb_args;
     std::vector<std::string> sdpb_out_filenames;
@@ -35,8 +37,6 @@ namespace
 
     void run()
     {
-      int diff_precision = precision / 2;
-
       const auto data_dir
         = Test_Config::test_data_dir / "end-to-end_tests" / name;
       auto data_input_dir = data_dir / "input";

--- a/test/src/integration_tests/util/diff_sdpb_out.cxx
+++ b/test/src/integration_tests/util/diff_sdpb_out.cxx
@@ -187,13 +187,21 @@ namespace
     CAPTURE(a_out_txt);
     CAPTURE(b_out_txt);
     Parse_Sdpb_Out_Txt a(a_out_txt);
-    Parse_Sdpb_Out_Txt b(a_out_txt);
+    Parse_Sdpb_Out_Txt b(b_out_txt);
 
     auto keys = keys_to_compare;
     // By default, test each key except for "Solver runtime"
     if(keys.empty())
-      keys = {"terminateReason", "primalObjective", "dualObjective",
-              "dualityGap",      "primalError",     "dualError"};
+      keys = {
+        "terminateReason",
+        "primalObjective",
+        "dualObjective",
+        // These errors are small (e.g. 1e-30 or 1e-200),
+        // so it doesn't make sense to compare them up to diff_precision.
+        // "dualityGap",
+        // "primalError",
+        // "dualError"
+      };
     CAPTURE(keys);
 
     for(const auto &key : keys)
@@ -388,7 +396,7 @@ namespace Test_Util::REQUIRE_Equal
     const auto vec_to_matrix
       = [&](const Float_Vector &vec) { return to_matrix(std::vector({vec})); };
 
-    const Parse_SDP sdp(sdp_dir,runner);
+    const Parse_SDP sdp(sdp_dir, runner);
     const auto y_vec = Parse_Matrix_Txt(sdpb_out_dir / "y.txt").elements;
     const Float_Matrix y = vec_to_matrix(y_vec);
 


### PR DESCRIPTION
`diff_sdpb_out_txt()` wasn't checking anything because of a typo.

Now, by default we compare `terminateReason`, `primalObjective` and `dualObjective`.
Default `diff_precision` corresponds to `dualityGapThreshold = 1e-30`.