### PR TITLE
Fix #295 Hot-starting from a sister-point checkpoint crashes mid-iteration with vector::_M_range_check 9 >= 5

### DIFF
--- a/src/sdp_solve/SDP_Solver/run/cholesky_decomposition.cxx
+++ b/src/sdp_solve/SDP_Solver/run/cholesky_decomposition.cxx
@@ -17,11 +17,12 @@ void cholesky_decomposition(const Block_Diagonal_Matrix &A,
         }
       catch(std::exception &e)
         {
+          const auto block_index = block_info.block_indices.at(b / 2);
+          const auto parity = b % 2;
           RUNTIME_ERROR("Error when computing Cholesky decomposition of "
                         "Block_Diagonal_Matrix ",
-                        name,
-                        ", block index = ", block_info.block_indices.at(b),
-                        ": ", e.what());
+                        name, ", block index = ", block_index,
+                        ", parity = ", parity, ": ", e.what());
         }
     }
 }


### PR DESCRIPTION
- Fixes #295

The crash happened due to block indexing error during exception logging.
The actual exception was:
> Error when computing Cholesky decomposition of Block_Diagonal_Matrix Y, block index = 2, parity = 1: A was not numerically HPD: 5 6 -5.47888e-465